### PR TITLE
Minor addition to README to alert DevKitC1 users about failing filesystem commands (no SD-card)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ bridge job, or host-side tooling.
 
 `NOTE:` The DevKitC1 does not come with an SD-card slot, so none of the filesystem
 utilities will work on first boot.  To work around this, a small ramfs partition
-can be created using "ramfs mount / 1m" to create a temporary root filesystem (which
+can be created using `ramfs mount / 1m` to create a temporary root filesystem (which
 will obviously disappear on reboot).
 
 ## Build

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ On headless builds, SolarOS starts the primary shell on `uart0` when UART is
 available. `cdc0` remains available for a later port shell session, log job,
 bridge job, or host-side tooling.
 
-NOTE: The DevKitC1 does not come with an SD-card slot, so none of the filesystem
+`NOTE:` The DevKitC1 does not come with an SD-card slot, so none of the filesystem
 utilities will work on first boot.  To work around this, a small ramfs partition
 can be created using "ramfs mount / 1m" to create a temporary root filesystem (which
 will obviously disappear on reboot).

--- a/README.md
+++ b/README.md
@@ -60,6 +60,11 @@ On headless builds, SolarOS starts the primary shell on `uart0` when UART is
 available. `cdc0` remains available for a later port shell session, log job,
 bridge job, or host-side tooling.
 
+NOTE: The DevKitC1 does not come with an SD-card slot, so none of the filesystem
+utilities will work on first boot.  To work around this, a small ramfs partition
+can be created using "ramfs mount / 1m" to create a temporary root filesystem (which
+will obviously disappear on reboot).
+
 ## Build
 
 This project uses PlatformIO with ESP-IDF through the pioarduino Espressif32 platform.


### PR DESCRIPTION
Added a paragraph to the DevKitC1 section of the README to explain why filesystem commands don't work and how to work around it.