### PR TITLE
Fix MeshCore Packet.h include collision with libssh2

### DIFF
--- a/src/vendor/meshcore/Dispatcher.h
+++ b/src/vendor/meshcore/Dispatcher.h
@@ -2,7 +2,7 @@
 
 #include <MeshCore.h>
 #include <Identity.h>
-#include <Packet.h>
+#include "Packet.h"
 #include <Utils.h>
 #include <string.h>
 

--- a/src/vendor/meshcore/README.solaros.md
+++ b/src/vendor/meshcore/README.solaros.md
@@ -26,7 +26,12 @@ Local audit patches:
   `MESHCORE_SOLAROS` build definition as SolarOS does not define Arduino's
   global `ESP32` macro;
 - allocation and radio ownership live in the SolarOS adapter, outside this
-  upstream subtree.
+  upstream subtree;
+- `Dispatcher.h` includes `"Packet.h"` rather than `<Packet.h>` so the
+  sibling header always wins. The libssh2 component publishes its private
+  `libssh2/src` directory on the global include path, and on case-insensitive
+  filesystems (macOS APFS) `<Packet.h>` otherwise resolves to libssh2's
+  `packet.h`.
 
 Upstream updates are explicit dependency bumps: replace the audited files,
 review the local patches, update the pinned hash above, and run the MeshCore


### PR DESCRIPTION
Two facts collide:

1. The `skuodi__libssh2_esp` component publishes its private source directory `libssh2/src` as a public `INCLUDE_DIRS` entry (`managed_components/skuodi__libssh2_esp/CMakeLists.txt`) — set(`INCLUDES ${LIBSSH2_DIR}/src ...)`). That directory contains packet.h.
2. macOS APFS is case-insensitive, so vendored MeshCore's #include <Packet.h> matches libssh2's packet.h.

Whether it breaks comes down to `-I` order. In the CMake/ninja graph `src/vendor/meshcore` sits at `-I` 10 and `libssh2/src` at 194 , so idf.py build and CI (case-sensitive Linux) are fine. But the failing run is PlatformIO's SCons rebuild (note it emits src/.../*.o, not ninja's *.obj), which reorders the merged include path and puts libssh2/src first — so <Packet.h> opens libssh2's private header, which has no LIBSSH2_SESSION in scope because libssh2_priv.h was never included.

Verified directly with the host preprocessor, libssh2 first on the path:

```
=== <Packet.h> ===  . managed_components/skuodi__libssh2_esp/libssh2/src/Packet.h   ← wrong file, same errors
=== "Packet.h" ===  . src/vendor/meshcore/Packet.h                                   ← correct
```