### PR TITLE
Fix replacing existing Game Boy save files

### DIFF
--- a/src/apps/solar_os_gameboy.c
+++ b/src/apps/solar_os_gameboy.c
@@ -131,10 +131,16 @@ static esp_err_t gameboy_write_save(void) {
     return ESP_OK;
   }
 
-  char temporary[SOLAR_OS_STORAGE_PATH_MAX + 5U];
-  if (snprintf(temporary, sizeof(temporary), "%s.tmp", gameboy.save_path) >=
-      (int)sizeof(temporary)) {
-    return ESP_ERR_INVALID_SIZE;
+  char temporary[SOLAR_OS_STORAGE_PATH_MAX];
+  char backup[SOLAR_OS_STORAGE_PATH_MAX];
+  esp_err_t err = solar_os_storage_sibling_path(
+      gameboy.save_path, ".tmp", temporary, sizeof(temporary));
+  if (err == ESP_OK) {
+    err = solar_os_storage_sibling_path(
+        gameboy.save_path, ".bak", backup, sizeof(backup));
+  }
+  if (err != ESP_OK) {
+    return err;
   }
   FILE *file = fopen(temporary, "wb");
   if (file == NULL) {
@@ -144,12 +150,13 @@ static esp_err_t gameboy_write_save(void) {
                              file) != gameboy.cart_ram_size ||
                       fflush(file) != 0 || fsync(fileno(file)) != 0;
   if (fclose(file) != 0 || failed) {
-    (void)remove(temporary);
+    (void)solar_os_storage_remove(temporary);
     return ESP_FAIL;
   }
-  if (rename(temporary, gameboy.save_path) != 0) {
-    (void)remove(temporary);
-    return ESP_FAIL;
+  err = solar_os_storage_replace_file(temporary, gameboy.save_path, backup);
+  if (err != ESP_OK) {
+    (void)solar_os_storage_remove(temporary);
+    return err;
   }
   gameboy.cart_ram_dirty = false;
   return ESP_OK;

--- a/src/apps/solar_os_gameboy.c
+++ b/src/apps/solar_os_gameboy.c
@@ -131,8 +131,8 @@ static esp_err_t gameboy_write_save(void) {
     return ESP_OK;
   }
 
-  char temporary[SOLAR_OS_STORAGE_PATH_MAX];
-  char backup[SOLAR_OS_STORAGE_PATH_MAX];
+  char temporary[SOLAR_OS_STORAGE_PATH_MAX + 5U];
+  char backup[SOLAR_OS_STORAGE_PATH_MAX + 5U];
   esp_err_t err = solar_os_storage_sibling_path(
       gameboy.save_path, ".tmp", temporary, sizeof(temporary));
   if (err == ESP_OK) {


### PR DESCRIPTION
## Summary

Fix Game Boy cartridge RAM persistence when a `.sav` file already exists.

The Game Boy app writes dirty cartridge RAM to a temporary file before installing it as the active `.sav`. The previous implementation renamed the temporary file directly over the existing save, which can fail on FAT-backed storage and leave the previous `.sav` in place.

Use SolarOS's existing storage replacement helpers to create checked sibling `.tmp` and `.bak` paths, move the previous active save aside, install the staged save, and restore the previous file if replacement fails.

The cartridge RAM dirty flag is cleared only after the new save has been successfully installed.

## Reproduction

1. Launch a battery-backed Game Boy title with no existing save.
2. Save in-game and quit.
3. Relaunch and load the save.
4. Make newer progress and save again.
5. Quit and relaunch.

Before this change, the previously persisted save could be loaded instead of the newer one because replacement of the existing `.sav` failed.

## Validation

- Built successfully for Waveshare ESP32-S3-RLCD-4.2.
- Hardware tested on Waveshare ESP32-S3-RLCD-4.2.
- Verified first-time `.sav` creation.
- Verified replacement of an existing `.sav` without manually renaming or deleting it.
- Verified the newer save persists after quitting and relaunching the Game Boy application.
- Verified repeated save/quit/relaunch cycles persist the latest save.
- Verified successful saves do not leave stale `.tmp` or `.bak` files.
- Relevant automated Game Boy/host tests pass.