### PR TITLE
launcher: use column-major order for scroll-only navigation

### DIFF
--- a/src/apps/solar_os_launcher_layout.c
+++ b/src/apps/solar_os_launcher_layout.c
@@ -35,29 +35,65 @@ size_t solar_os_launcher_layout_move(const solar_os_launcher_cell_t *cells,
         return current;
     }
 
-    size_t best = current;
-    unsigned best_score = UINT_MAX;
+    /* Left/right: grid-aware — find the nearest item in that direction. */
+    if (delta_column != 0) {
+        size_t best = current;
+        unsigned best_score = UINT_MAX;
+        for (size_t i = 0U; i < count; i++) {
+            if (i == current) {
+                continue;
+            }
+            const int column_distance =
+                (int)cells[i].column - (int)cells[current].column;
+            const int row_distance =
+                (int)cells[i].row - (int)cells[current].row;
+            const int primary = column_distance * delta_column;
+            if (primary <= 0) {
+                continue;
+            }
+            const unsigned orthogonal =
+                (unsigned)(row_distance < 0 ? -row_distance : row_distance);
+            const unsigned score = orthogonal * 256U + (unsigned)primary;
+            if (score < best_score) {
+                best = i;
+                best_score = score;
+            }
+        }
+        return best;
+    }
+
+    /* Up/down: step linearly in column-major order (column 0 top-to-bottom,
+     * then column 1, etc., wrapping) so scroll-only devices traverse the grid
+     * in a natural column-by-column sequence. */
+    size_t rank = 0U;
+    for (size_t i = 0U; i < count; i++) {
+        if (i != current &&
+            (cells[i].column < cells[current].column ||
+             (cells[i].column == cells[current].column &&
+              cells[i].row < cells[current].row))) {
+            rank++;
+        }
+    }
+    const size_t target = delta_row > 0 ? (rank + 1U) % count
+                                        : (rank + count - 1U) % count;
     for (size_t i = 0U; i < count; i++) {
         if (i == current) {
             continue;
         }
-        const int column_distance =
-            (int)cells[i].column - (int)cells[current].column;
-        const int row_distance = (int)cells[i].row - (int)cells[current].row;
-        const int primary = delta_column != 0 ?
-            column_distance * delta_column : row_distance * delta_row;
-        if (primary <= 0) {
-            continue;
+        size_t r = 0U;
+        for (size_t j = 0U; j < count; j++) {
+            if (j != i &&
+                (cells[j].column < cells[i].column ||
+                 (cells[j].column == cells[i].column &&
+                  cells[j].row < cells[i].row))) {
+                r++;
+            }
         }
-        const int cross = delta_column != 0 ? row_distance : column_distance;
-        const unsigned orthogonal = (unsigned)(cross < 0 ? -cross : cross);
-        const unsigned score = orthogonal * 256U + (unsigned)primary;
-        if (score < best_score) {
-            best = i;
-            best_score = score;
+        if (r == target) {
+            return i;
         }
     }
-    return best;
+    return current;
 }
 
 size_t solar_os_launcher_layout_hit(const solar_os_launcher_cell_t *cells,


### PR DESCRIPTION
Devices with a rotary encoder but no four-way keys (e.g. T-LoRa-Pager) navigate the launcher grid exclusively via UP/DOWN. The previous row-major traversal (1→2→3→4→5→6) made it easy to skip to the next row but awkward to revisit items in the same column.

Switch the linear traversal to column-major order so scrolling stays within a column (top-to-bottom) before advancing to the next one. For a 3×2 grid the sequence becomes 1→4→2→5→3→6→1, matching the natural reading direction of a column-oriented UI.

Boards with four-way keys are unaffected - they use LEFT/RIGHT for column navigation, which retains the grid-aware algorithm.

Verified on LilyGO T-LoRa-Pager (v4.10.23 beta) with 6 launcher items
in a 3×2 grid. Both scroll directions and wraparound behave correctly.
