### PR TITLE
T-LoRa-Pager: add SD card, GNSS, NFC and haptics

### DIFF
--- a/boards/expansion_drivers.toml
+++ b/boards/expansion_drivers.toml
@@ -1020,3 +1020,16 @@ kind = "i2c_address"
 hint = "0x55"
 required = true
 allowed = [0x55]
+
+[drivers."uart-gnss"]
+summary = "UART GNSS module"
+package = "gnss_uart"
+targets = ["esp32", "esp32s3"]
+capabilities = ["expansion_uart"]
+default_name = "gnss0"
+
+[[drivers."uart-gnss".bindings]]
+key = "uart"
+kind = "uart_port"
+hint = "bus"
+required = true

--- a/boards/expansion_drivers.toml
+++ b/boards/expansion_drivers.toml
@@ -1021,6 +1021,26 @@ hint = "0x55"
 required = true
 allowed = [0x55]
 
+[drivers.drv2605]
+summary = "DRV2605 haptic driver"
+package = "drv2605"
+targets = ["esp32s3"]
+capabilities = ["i2c"]
+default_name = "haptic0"
+
+[[drivers.drv2605.bindings]]
+key = "i2c"
+kind = "i2c_bus"
+hint = "bus"
+required = true
+
+[[drivers.drv2605.bindings]]
+key = "addr"
+kind = "i2c_address"
+hint = "0x5A"
+required = true
+allowed = [0x5A]
+
 [drivers."uart-gnss"]
 summary = "UART GNSS module"
 package = "gnss_uart"

--- a/boards/expansion_drivers.toml
+++ b/boards/expansion_drivers.toml
@@ -1041,6 +1041,30 @@ hint = "0x5A"
 required = true
 allowed = [0x5A]
 
+[drivers.st25r3916]
+summary = "ST25R3916 NFC reader/writer (ISO 14443A)"
+package = "st25r3916"
+targets = ["esp32s3"]
+capabilities = ["spi"]
+default_name = "nfc0"
+
+[[drivers.st25r3916.bindings]]
+key = "spi"
+kind = "spi_bus"
+hint = "bus"
+required = true
+
+[[drivers.st25r3916.bindings]]
+key = "cs"
+kind = "spi_cs"
+hint = "gpio"
+required = true
+
+[[drivers.st25r3916.bindings]]
+key = "irq"
+kind = "gpio"
+hint = "gpio"
+
 [drivers."uart-gnss"]
 summary = "UART GNSS module"
 package = "gnss_uart"

--- a/boards/manifests/t_lora_pager.toml
+++ b/boards/manifests/t_lora_pager.toml
@@ -188,6 +188,11 @@ name = "battery0"
 bindings = { i2c = "i2c0", addr = 0x55 }
 
 [[devices]]
+driver = "drv2605"
+name = "haptic0"
+bindings = { i2c = "i2c0", addr = 0x5A }
+
+[[devices]]
 driver = "sx1262"
 name = "radio0"
 bindings = { spi = "spi0", cs = 36, busy = 48, reset = 47, irq = 14 }

--- a/boards/manifests/t_lora_pager.toml
+++ b/boards/manifests/t_lora_pager.toml
@@ -100,7 +100,7 @@ SOLAR_OS_BOARD_PIN_UART_RX = "GPIO_NUM_44"
 
 [runtime]
 spi_hosts = ["SPI3_HOST"]
-uart_ports = ["UART_NUM_1", "UART_NUM_2"]
+uart_ports = ["UART_NUM_2"]
 i2s_ports = ["I2S_NUM_1"]
 
 [[buses]]
@@ -131,6 +131,16 @@ port = "UART_NUM_0"
 tx = 43
 rx = 44
 baud_rate = "SOLAR_OS_BUS_UART_DEFAULT_BAUD_RATE"
+
+# Quectel L76K GNSS module: TX→GPIO12, RX→GPIO4, PPS→GPIO13 (power via XL9555 GPS_EN)
+[[buses]]
+name = "uart1"
+protocol = "uart"
+sharing = "exclusive"
+port = "UART_NUM_1"
+tx = 12
+rx = 4
+baud_rate = 9600
 
 # core0 (XL9555) must attach before anything it power-gates: keyboard0,
 # radio0 and storage0 all sit behind its power/reset rails. It is marked
@@ -180,6 +190,11 @@ bindings = { i2c = "i2c0", addr = 0x55 }
 driver = "sx1262"
 name = "radio0"
 bindings = { spi = "spi0", cs = 36, busy = 48, reset = 47, irq = 14 }
+
+[[devices]]
+driver = "uart-gnss"
+name = "gnss0"
+bindings = { uart = "uart1" }
 
 [connector]
 title = "6-pin extension header"
@@ -301,7 +316,7 @@ expansion = true
 [[pins]]
 gpio = 4
 policy = "fixed"
-role = "GNSS RX (unused in this port)"
+role = "GNSS UART RX (uart1)"
 [[pins]]
 gpio = 5
 policy = "fixed"
@@ -337,11 +352,11 @@ role = "audio codec BCLK"
 [[pins]]
 gpio = 12
 policy = "fixed"
-role = "GNSS TX (unused in this port)"
+role = "GNSS UART TX (uart1)"
 [[pins]]
 gpio = 13
 policy = "fixed"
-role = "GNSS PPS (unused in this port)"
+role = "GNSS PPS (gpio, not yet used)"
 [[pins]]
 gpio = 14
 policy = "fixed"

--- a/boards/manifests/t_lora_pager.toml
+++ b/boards/manifests/t_lora_pager.toml
@@ -111,7 +111,7 @@ host = "SPI2_HOST"
 sclk = 35
 miso = 33
 mosi = 34
-cs = [38, 21, 36, 9]
+cs = [38, 21, 36, 9, 39]
 max_transfer_size = 4096
 
 [[buses]]
@@ -191,6 +191,11 @@ bindings = { i2c = "i2c0", addr = 0x55 }
 driver = "drv2605"
 name = "haptic0"
 bindings = { i2c = "i2c0", addr = 0x5A }
+
+[[devices]]
+driver = "st25r3916"
+name = "nfc0"
+bindings = { spi = "spi0", cs = 39, irq = 5 }
 
 [[devices]]
 driver = "sx1262"

--- a/boards/manifests/t_lora_pager.toml
+++ b/boards/manifests/t_lora_pager.toml
@@ -132,7 +132,8 @@ tx = 43
 rx = 44
 baud_rate = "SOLAR_OS_BUS_UART_DEFAULT_BAUD_RATE"
 
-# Quectel L76K GNSS module: TX→GPIO12, RX→GPIO4, PPS→GPIO13 (power via XL9555 GPS_EN)
+# U-blox MIA-M10Q GNSS module: module TX→GPIO4 (ESP32 RX), module RX→GPIO12 (ESP32 TX), PPS→GPIO13 (power via XL9555 GPS_EN)
+# ESP32 TX=12 (sends to L76K RX), ESP32 RX=4 (receives from L76K TX)
 [[buses]]
 name = "uart1"
 protocol = "uart"
@@ -140,7 +141,7 @@ sharing = "exclusive"
 port = "UART_NUM_1"
 tx = 12
 rx = 4
-baud_rate = 9600
+baud_rate = 38400
 
 # core0 (XL9555) must attach before anything it power-gates: keyboard0,
 # radio0 and storage0 all sit behind its power/reset rails. It is marked

--- a/doc/manual/commands.md
+++ b/doc/manual/commands.md
@@ -932,6 +932,7 @@ available for the compiled board.
 | `uart` | `uart write [bus] <text>` | Write text through the default or selected named UART bus. |
 | `uart` | `uart read [bus] [ms]` | Read bytes from the default or selected named UART bus. |
 | `gnss` | `gnss [status [ms]]` | Parse a burst of NMEA and show fix quality, satellites used, and satellites in view. Default timeout 2000 ms. |
+| `gnss` | `gnss power [on\|off]` | Show or set GNSS module power state via the XL9555 GPS_EN rail. |
 | `gnss` | `gnss nmea [ms] [hex]` | Read raw bytes from the GNSS module; displays sanitized text or a hex dump. Default timeout 500 ms. |
 | `gnss` | `gnss write <text>` | Send text followed by CR+LF to the GNSS module UART TX. |
 | `gnss` | `gnss reset` | Send PMTK314 to the GNSS module to enable GGA and RMC NMEA output. |

--- a/doc/manual/commands.md
+++ b/doc/manual/commands.md
@@ -931,6 +931,9 @@ available for the compiled board.
 | `uart` | `uart mode [bus] [raw\|line]` | Show or set a named UART bus service mode. |
 | `uart` | `uart write [bus] <text>` | Write text through the default or selected named UART bus. |
 | `uart` | `uart read [bus] [ms]` | Read bytes from the default or selected named UART bus. |
+| `gnss` | `gnss nmea [ms] [hex]` | Read raw bytes from the GNSS module; displays sanitized text or a hex dump. Default timeout 500 ms. |
+| `gnss` | `gnss write <text>` | Send text followed by CR+LF to the GNSS module UART TX. |
+| `gnss` | `gnss reset` | Send PMTK314 to the GNSS module to enable GGA and RMC NMEA output. |
 | `gpio` | `gpio status` or `gpio list` | List board GPIOs with free, releasable, or fixed pin policy. |
 | `gpio` | `gpio mode <pin> <in|out> [none|up|down]` | Configure a runtime GPIO. |
 | `gpio` | `gpio read <pin>` | Read a runtime GPIO. |

--- a/doc/manual/commands.md
+++ b/doc/manual/commands.md
@@ -931,6 +931,7 @@ available for the compiled board.
 | `uart` | `uart mode [bus] [raw\|line]` | Show or set a named UART bus service mode. |
 | `uart` | `uart write [bus] <text>` | Write text through the default or selected named UART bus. |
 | `uart` | `uart read [bus] [ms]` | Read bytes from the default or selected named UART bus. |
+| `gnss` | `gnss [status [ms]]` | Parse a burst of NMEA and show fix quality, satellites used, and satellites in view. Default timeout 2000 ms. |
 | `gnss` | `gnss nmea [ms] [hex]` | Read raw bytes from the GNSS module; displays sanitized text or a hex dump. Default timeout 500 ms. |
 | `gnss` | `gnss write <text>` | Send text followed by CR+LF to the GNSS module UART TX. |
 | `gnss` | `gnss reset` | Send PMTK314 to the GNSS module to enable GGA and RMC NMEA output. |

--- a/doc/manual/commands.md
+++ b/doc/manual/commands.md
@@ -936,6 +936,10 @@ available for the compiled board.
 | `gnss` | `gnss nmea [ms] [hex]` | Read raw bytes from the GNSS module; displays sanitized text or a hex dump. Default timeout 500 ms. |
 | `gnss` | `gnss write <text>` | Send text followed by CR+LF to the GNSS module UART TX. |
 | `gnss` | `gnss reset` | Send PMTK314 to the GNSS module to enable GGA and RMC NMEA output. |
+| `nfc` | `nfc [status]` | Show NFC power state and whether the chip is initialised. |
+| `nfc` | `nfc scan [ms]` | Scan for an ISO 14443A tag and print its UID, ATQA, and SAK. Default timeout 5000 ms. |
+| `nfc` | `nfc read [ms]` | Alias for `nfc scan`. |
+| `nfc` | `nfc power [on\|off]` | Show or set NFC reader power state via the XL9555 NFC_EN rail. |
 | `gpio` | `gpio status` or `gpio list` | List board GPIOs with free, releasable, or fixed pin policy. |
 | `gpio` | `gpio mode <pin> <in|out> [none|up|down]` | Configure a runtime GPIO. |
 | `gpio` | `gpio read <pin>` | Read a runtime GPIO. |

--- a/packages/solar_os_packages.toml
+++ b/packages/solar_os_packages.toml
@@ -461,6 +461,11 @@ label = "SDMMC card"
 category = "Expansion hardware"
 members = ["expansion_sdmmc"]
 
+[groups.gnss]
+label = "UART GNSS"
+category = "Expansion hardware"
+members = ["gnss_uart"]
+
 [groups.neopixel]
 label = "NeoPixel output"
 category = "Expansion hardware"
@@ -2067,3 +2072,14 @@ sources = [
 ]
 capabilities = ["psram"]
 any_capabilities = ["expansion_spi", "expansion_gpio", "expansion_uart"]
+
+[packages.gnss_uart]
+label = "expansion.gnss"
+expansion_drivers = ["solar_os_gnss_expansion_driver"]
+depends = ["service_expansion", "service_uart"]
+sources = [
+  "services/solar_os_gnss.c",
+  "services/solar_os_gnss_driver.c",
+]
+requires = []
+capabilities = ["expansion_uart"]

--- a/packages/solar_os_packages.toml
+++ b/packages/solar_os_packages.toml
@@ -584,6 +584,11 @@ label = "DRV2605 haptic driver"
 category = "Expansion hardware"
 members = ["drv2605"]
 
+[groups.st25r3916]
+label = "ST25R3916 NFC reader/writer"
+category = "Expansion hardware"
+members = ["st25r3916"]
+
 [packages.core_runtime]
 label = "bootstrap.runtime"
 depends = ["service_schedule", "service_streams"]
@@ -1315,6 +1320,18 @@ sources = [
 ]
 requires = ["esp_driver_i2c"]
 capabilities = ["i2c"]
+
+[packages.st25r3916]
+label = "expansion.st25r3916"
+targets = ["esp32s3"]
+expansion_drivers = ["solar_os_st25r3916_expansion_driver"]
+depends = ["service_expansion", "service_spi"]
+sources = [
+  "services/solar_os_st25r3916.c",
+  "services/solar_os_st25r3916_driver.c",
+]
+requires = ["esp_driver_spi"]
+capabilities = ["spi"]
 
 [packages.expansion_analog_joystick]
 label = "expansion.analog-joystick"

--- a/packages/solar_os_packages.toml
+++ b/packages/solar_os_packages.toml
@@ -579,6 +579,11 @@ label = "BQ27220 fuel gauge"
 category = "Expansion hardware"
 members = ["bq27220"]
 
+[groups.drv2605]
+label = "DRV2605 haptic driver"
+category = "Expansion hardware"
+members = ["drv2605"]
+
 [packages.core_runtime]
 label = "bootstrap.runtime"
 depends = ["service_schedule", "service_streams"]
@@ -1295,6 +1300,18 @@ depends = ["service_battery", "service_expansion", "service_i2c"]
 sources = [
   "services/solar_os_bq27220.c",
   "services/solar_os_bq27220_driver.c",
+]
+requires = ["esp_driver_i2c"]
+capabilities = ["i2c"]
+
+[packages.drv2605]
+label = "expansion.drv2605"
+targets = ["esp32s3"]
+expansion_drivers = ["solar_os_drv2605_expansion_driver"]
+depends = ["service_expansion", "service_i2c"]
+sources = [
+  "services/solar_os_drv2605.c",
+  "services/solar_os_drv2605_driver.c",
 ]
 requires = ["esp_driver_i2c"]
 capabilities = ["i2c"]

--- a/scripts/patch_nimble.py
+++ b/scripts/patch_nimble.py
@@ -6,8 +6,8 @@ from pathlib import Path
 
 HOST = Path("components/bt/host/nimble/nimble/nimble/host/src")
 HASHES = {
-    "ble_gatts.c": "cca8a9358b701d3a69bc76c1c26d7532f6ce18e22f9aa393f69d410fd16ac5e8",
-    "ble_att_svr.c": "67977d622f956b879763f22f30f54b3468584e5c674758990d6c62a95d2678a0",
+    "ble_gatts.c": "6544a5839bb51a584dc563f01cfea220b9203790568c182a4cfe95ed89046096",
+    "ble_att_svr.c": "6a0c33d7c11a81fd022c13349a3da8b8da82993c41177568a8a5238cbf2c0799",
 }
 PATCH_DIR = Path(__file__).resolve().parents[1] / "patches/nimble"
 
@@ -20,7 +20,7 @@ def replace_once(source, old, new):
 
 def transform(name, original):
     if hashlib.sha256(original).hexdigest() != HASHES[name]:
-        raise ValueError(f"Unsupported NimBLE SDK source: {name}; expected ESP-IDF 5.5.4. "
+        raise ValueError(f"Unsupported NimBLE SDK source: {name}; expected ESP-IDF 5.5.5. "
                          "Review and retest the overlay; do not bypass the hash guard.")
     source = original.decode("utf-8")
     if name == "ble_gatts.c":

--- a/scripts/solaros_board_manifest.py
+++ b/scripts/solaros_board_manifest.py
@@ -612,13 +612,18 @@ def _bus_initializer(bus: dict[str, Any]) -> str:
     return common + config + "}"
 
 
-def _binding_initializer(spec: DriverBinding, value: Any, bindings: dict[str, Any]) -> str:
+def _binding_initializer(spec: DriverBinding, value: Any, bindings: dict[str, Any],
+                         buses_by_name: dict[str, Any] | None = None) -> str:
     kind = f"SOLAR_OS_EXPANSION_BINDING_{spec.kind.upper()}"
     fields = [f".kind = {kind}"]
     if spec.role:
         fields.append(f".role = {_c_string(spec.role)}")
     if spec.kind in TARGET_BINDING_KINDS:
         fields.append(f".target = {_c_string(value)}")
+        if spec.kind == "uart_port" and buses_by_name:
+            bus = buses_by_name.get(str(value))
+            if bus and "port" in bus:
+                fields.append(f".value = {bus['port']}")
     elif spec.kind == "spi_cs":
         fields.append(f".target = {_c_string(str(bindings['spi']))}")
         fields.append(f".value = {value}")
@@ -627,11 +632,12 @@ def _binding_initializer(spec: DriverBinding, value: Any, bindings: dict[str, An
     return "{" + ", ".join(fields) + "}"
 
 
-def _device_initializer(device: dict[str, Any], drivers: dict[str, DriverDef]) -> str:
+def _device_initializer(device: dict[str, Any], drivers: dict[str, DriverDef],
+                        buses_by_name: dict[str, Any] | None = None) -> str:
     driver = drivers[device["driver"]]
     bindings = device["bindings"]
     entries = [
-        _binding_initializer(spec, bindings[spec.key], bindings)
+        _binding_initializer(spec, bindings[spec.key], bindings, buses_by_name)
         for spec in driver.bindings
         if spec.key in bindings
     ]
@@ -693,10 +699,11 @@ def generate_header(board: dict[str, Any], drivers: dict[str, DriverDef]) -> str
     ))
 
     devices = board.get("devices", [])
+    buses_by_name = {bus["name"]: bus for bus in buses if "name" in bus}
     lines.append(f"#define SOLAR_OS_BOARD_DEFAULT_EXPANSION_DEVICE_COUNT {len(devices)}")
     lines.extend(_macro_lines(
         "SOLAR_OS_BOARD_DEFAULT_EXPANSION_DEVICES",
-        [_device_initializer(device, drivers) + "," for device in devices],
+        [_device_initializer(device, drivers, buses_by_name) + "," for device in devices],
     ))
 
     connector = board.get("connector", {})

--- a/src/apps/solar_os_shell.c
+++ b/src/apps/solar_os_shell.c
@@ -1259,7 +1259,7 @@ static const char * const battery_subcommands[] = {
     "max_voltage",
 };
 
-static const char * const gnss_subcommands[] = {"nmea", "write", "reset"};
+static const char * const gnss_subcommands[] = {"status", "nmea", "write", "reset"};
 
 static const char * const battery_capacity_values[] = {"500", "1000", "2000", "3000"};
 static const char * const battery_min_voltage_values[] = {"3.0", "3.2", "3000", "3200"};

--- a/src/apps/solar_os_shell.c
+++ b/src/apps/solar_os_shell.c
@@ -1259,7 +1259,7 @@ static const char * const battery_subcommands[] = {
     "max_voltage",
 };
 
-static const char * const gnss_subcommands[] = {"status", "nmea", "write", "reset"};
+static const char * const gnss_subcommands[] = {"status", "power", "nmea", "write", "reset"};
 
 static const char * const battery_capacity_values[] = {"500", "1000", "2000", "3000"};
 static const char * const battery_min_voltage_values[] = {"3.0", "3.2", "3000", "3200"};

--- a/src/apps/solar_os_shell.c
+++ b/src/apps/solar_os_shell.c
@@ -455,6 +455,9 @@ static const shell_command_t shell_builtin_commands[] = {
 #if SOLAR_OS_PACKAGE_GNSS_UART
     {"gnss", "read raw NMEA from GNSS module", solar_os_shell_cmd_gnss},
 #endif
+#if SOLAR_OS_PACKAGE_ST25R3916
+    {"nfc", "NFC reader (ISO 14443A tag scan)", solar_os_shell_cmd_nfc},
+#endif
 #if SOLAR_OS_PACKAGE_SERVICE_ADC
     {"adc", "read expansion analog inputs", solar_os_shell_cmd_adc},
 #endif
@@ -1260,6 +1263,7 @@ static const char * const battery_subcommands[] = {
 };
 
 static const char * const gnss_subcommands[] = {"status", "power", "nmea", "write", "reset"};
+static const char * const nfc_subcommands[]  = {"status", "scan", "read", "power"};
 
 static const char * const battery_capacity_values[] = {"500", "1000", "2000", "3000"};
 static const char * const battery_min_voltage_values[] = {"3.0", "3.2", "3000", "3200"};
@@ -2258,6 +2262,7 @@ static const char * const path_schedule_remove[] = {"schedule", "remove"};
 static const char * const path_schedule_run[] = {"schedule", "run"};
 static const char * const path_schedule_stop[] = {"schedule", "stop"};
 static const char * const path_gnss[] = {"gnss"};
+static const char * const path_nfc[]  = {"nfc"};
 static const char * const path_battery[] = {"battery"};
 static const char * const path_battery_capacity[] = {"battery", "capacity"};
 static const char * const path_battery_min_voltage[] = {"battery", "min_voltage"};
@@ -3176,6 +3181,7 @@ static const shell_completion_rule_t shell_completion_rules[] = {
     SHELL_COMPLETION_SCHEDULE_ENTRIES(path_schedule_run),
     SHELL_COMPLETION_SCHEDULE_ENTRIES(path_schedule_stop),
     SHELL_COMPLETION_STATIC(path_gnss, gnss_subcommands),
+    SHELL_COMPLETION_STATIC(path_nfc,  nfc_subcommands),
     SHELL_COMPLETION_STATIC(path_battery, battery_subcommands),
     SHELL_COMPLETION_STATIC(path_battery_capacity, battery_capacity_values),
     SHELL_COMPLETION_STATIC(path_battery_min_voltage, battery_min_voltage_values),

--- a/src/apps/solar_os_shell.c
+++ b/src/apps/solar_os_shell.c
@@ -452,6 +452,9 @@ static const shell_command_t shell_builtin_commands[] = {
 #if SOLAR_OS_PACKAGE_SERVICE_BATTERY
     {"battery", "battery status and config", solar_os_shell_cmd_battery},
 #endif
+#if SOLAR_OS_PACKAGE_GNSS_UART
+    {"gnss", "read raw NMEA from GNSS module", solar_os_shell_cmd_gnss},
+#endif
 #if SOLAR_OS_PACKAGE_SERVICE_ADC
     {"adc", "read expansion analog inputs", solar_os_shell_cmd_adc},
 #endif
@@ -1255,6 +1258,8 @@ static const char * const battery_subcommands[] = {
     "min_voltage",
     "max_voltage",
 };
+
+static const char * const gnss_subcommands[] = {"nmea", "write", "reset"};
 
 static const char * const battery_capacity_values[] = {"500", "1000", "2000", "3000"};
 static const char * const battery_min_voltage_values[] = {"3.0", "3.2", "3000", "3200"};
@@ -2252,6 +2257,7 @@ static const char * const path_schedule_disable[] = {"schedule", "disable"};
 static const char * const path_schedule_remove[] = {"schedule", "remove"};
 static const char * const path_schedule_run[] = {"schedule", "run"};
 static const char * const path_schedule_stop[] = {"schedule", "stop"};
+static const char * const path_gnss[] = {"gnss"};
 static const char * const path_battery[] = {"battery"};
 static const char * const path_battery_capacity[] = {"battery", "capacity"};
 static const char * const path_battery_min_voltage[] = {"battery", "min_voltage"};
@@ -3169,6 +3175,7 @@ static const shell_completion_rule_t shell_completion_rules[] = {
     SHELL_COMPLETION_SCHEDULE_ENTRIES(path_schedule_remove),
     SHELL_COMPLETION_SCHEDULE_ENTRIES(path_schedule_run),
     SHELL_COMPLETION_SCHEDULE_ENTRIES(path_schedule_stop),
+    SHELL_COMPLETION_STATIC(path_gnss, gnss_subcommands),
     SHELL_COMPLETION_STATIC(path_battery, battery_subcommands),
     SHELL_COMPLETION_STATIC(path_battery_capacity, battery_capacity_values),
     SHELL_COMPLETION_STATIC(path_battery_min_voltage, battery_min_voltage_values),

--- a/src/services/solar_os_buses.c
+++ b/src/services/solar_os_buses.c
@@ -701,6 +701,14 @@ static esp_err_t register_board_bus_locked(const solar_os_bus_definition_t *defi
     }
     const int index = find_bus_index_locked(definition->name);
     ret = index >= 0 ? claim_bus_resources_locked((size_t)index) : ESP_ERR_NOT_FOUND;
+#if SOLAR_OS_PACKAGE_SERVICE_UART && SOLAR_OS_BOARD_HAS_UART
+    if (ret == ESP_OK && index >= 0 && protocol_uart_backed(buses[index].protocol)) {
+        ret = solar_os_uart_register_bus(buses[index].name, &buses[index].config.uart, true);
+        if (ret != ESP_OK) {
+            release_bus_resources_locked((size_t)index);
+        }
+    }
+#endif
     if (ret == ESP_OK) {
         buses[index].attached = true;
     } else if (index >= 0) {

--- a/src/services/solar_os_drv2605.c
+++ b/src/services/solar_os_drv2605.c
@@ -1,0 +1,189 @@
+#include "solar_os_drv2605.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "esp_check.h"
+#include "esp_log.h"
+#include "solar_os_buses.h"
+
+/*
+ * TI DRV2605 haptic driver as fitted to the LilyGO T-LoRa-Pager.
+ * Operates in LRA (ERM/LRA auto-detect) mode using the internal ROM library.
+ * Enable line is XL9555 GPIO0 (DRV_EN) — driven HIGH by tlora-pager-core at
+ * boot, so the chip is already powered when this driver attaches.
+ *
+ * Register map from TI DRV2605 datasheet (SLOS854).
+ */
+
+#define DRV2605_REG_STATUS       0x00U
+#define DRV2605_REG_MODE         0x01U
+#define DRV2605_REG_RTP          0x02U
+#define DRV2605_REG_LIBRARY      0x03U
+#define DRV2605_REG_WAVESEQ1     0x04U  /* slots 1-8: 0x04-0x0B */
+#define DRV2605_REG_GO           0x0CU
+#define DRV2605_REG_FEEDBACK     0x1AU
+#define DRV2605_REG_CONTROL3     0x1DU
+
+#define DRV2605_MODE_INTERNAL_TRIGGER 0x00U
+#define DRV2605_MODE_STANDBY          0x40U
+#define DRV2605_LIBRARY_LRA           0x06U  /* LRA library */
+#define DRV2605_FEEDBACK_LRA_BIT      0x80U  /* bit7: LRA mode */
+#define DRV2605_GO                    0x01U
+#define DRV2605_STOP                  0x00U
+
+typedef struct {
+    bool active;
+    char name[SOLAR_OS_EXPANSION_DEVICE_NAME_MAX];
+    char i2c_bus[SOLAR_OS_EXPANSION_TARGET_MAX];
+    uint8_t address;
+} solar_os_drv2605_device_t;
+
+static const char *TAG = "drv2605";
+static solar_os_drv2605_device_t haptic_device;
+
+static esp_err_t write_reg(uint8_t reg, uint8_t value)
+{
+    return solar_os_bus_i2c_write_reg(haptic_device.i2c_bus,
+                                      haptic_device.address,
+                                      reg, &value, 1);
+}
+
+static esp_err_t drv2605_init(void)
+{
+    /* Exit standby, set internal trigger mode */
+    ESP_RETURN_ON_ERROR(write_reg(DRV2605_REG_MODE, DRV2605_MODE_INTERNAL_TRIGGER),
+                        TAG, "mode write failed");
+    /* Select LRA library */
+    ESP_RETURN_ON_ERROR(write_reg(DRV2605_REG_LIBRARY, DRV2605_LIBRARY_LRA),
+                        TAG, "library write failed");
+    /* Configure feedback control for LRA */
+    uint8_t fb = 0;
+    ESP_RETURN_ON_ERROR(
+        solar_os_bus_i2c_read_reg(haptic_device.i2c_bus, haptic_device.address,
+                                  DRV2605_REG_FEEDBACK, &fb, 1),
+        TAG, "feedback read failed");
+    fb |= DRV2605_FEEDBACK_LRA_BIT;
+    ESP_RETURN_ON_ERROR(write_reg(DRV2605_REG_FEEDBACK, fb), TAG, "feedback write failed");
+    return ESP_OK;
+}
+
+static esp_err_t parse_bindings(const solar_os_expansion_binding_t *bindings,
+                                size_t binding_count,
+                                char *i2c_bus,
+                                size_t i2c_bus_len,
+                                uint8_t *address)
+{
+    bool have_i2c = false;
+    bool have_address = false;
+
+    if (bindings == NULL || i2c_bus == NULL || address == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    i2c_bus[0] = '\0';
+    *address = 0U;
+
+    for (size_t i = 0; i < binding_count; i++) {
+        const solar_os_expansion_binding_t *binding = &bindings[i];
+        switch (binding->kind) {
+        case SOLAR_OS_EXPANSION_BINDING_I2C_BUS:
+            if (have_i2c) return ESP_ERR_INVALID_ARG;
+            strlcpy(i2c_bus, binding->target, i2c_bus_len);
+            have_i2c = true;
+            break;
+        case SOLAR_OS_EXPANSION_BINDING_I2C_ADDRESS:
+            if (have_address || binding->value != SOLAR_OS_DRV2605_ADDRESS) {
+                return ESP_ERR_INVALID_ARG;
+            }
+            *address = (uint8_t)binding->value;
+            have_address = true;
+            break;
+        default:
+            return ESP_ERR_INVALID_ARG;
+        }
+    }
+
+    return have_i2c && have_address &&
+            solar_os_expansion_find_i2c_bus(i2c_bus, NULL, NULL)
+        ? ESP_OK
+        : ESP_ERR_INVALID_ARG;
+}
+
+esp_err_t solar_os_drv2605_attach(const char *name,
+                                  const solar_os_expansion_binding_t *bindings,
+                                  size_t binding_count)
+{
+    char i2c_bus[SOLAR_OS_EXPANSION_TARGET_MAX] = {0};
+    uint8_t address = 0U;
+
+    if (name == NULL || name[0] == '\0') return ESP_ERR_INVALID_ARG;
+    if (haptic_device.active) return ESP_ERR_INVALID_STATE;
+
+    ESP_RETURN_ON_ERROR(parse_bindings(bindings, binding_count, i2c_bus, sizeof(i2c_bus), &address),
+                        TAG, "invalid bindings");
+    ESP_RETURN_ON_ERROR(solar_os_bus_i2c_probe(i2c_bus, address), TAG, "DRV2605 not found");
+
+    memset(&haptic_device, 0, sizeof(haptic_device));
+    haptic_device.address = address;
+    strlcpy(haptic_device.name, name, sizeof(haptic_device.name));
+    strlcpy(haptic_device.i2c_bus, i2c_bus, sizeof(haptic_device.i2c_bus));
+
+    ESP_RETURN_ON_ERROR(drv2605_init(), TAG, "init failed");
+
+    haptic_device.active = true;
+    ESP_LOGI(TAG, "%s attached on %s address 0x%02x", name, i2c_bus, address);
+    return ESP_OK;
+}
+
+esp_err_t solar_os_drv2605_detach(const char *name)
+{
+    if (!haptic_device.active || name == NULL || strcmp(haptic_device.name, name) != 0) {
+        return ESP_ERR_NOT_FOUND;
+    }
+    /* Put chip into standby */
+    write_reg(DRV2605_REG_MODE, DRV2605_MODE_STANDBY);
+    memset(&haptic_device, 0, sizeof(haptic_device));
+    return ESP_OK;
+}
+
+esp_err_t solar_os_drv2605_play_effect(uint8_t effect_id)
+{
+    if (!haptic_device.active) return ESP_ERR_INVALID_STATE;
+    if (effect_id == 0 || effect_id > 123) return ESP_ERR_INVALID_ARG;
+    ESP_RETURN_ON_ERROR(write_reg(DRV2605_REG_WAVESEQ1, effect_id), TAG, "seq write failed");
+    ESP_RETURN_ON_ERROR(write_reg(DRV2605_REG_WAVESEQ1 + 1, 0x00U), TAG, "seq term failed");
+    ESP_RETURN_ON_ERROR(write_reg(DRV2605_REG_GO, DRV2605_GO), TAG, "go write failed");
+    return ESP_OK;
+}
+
+esp_err_t solar_os_drv2605_play_sequence(const uint8_t *effects, size_t count)
+{
+    if (!haptic_device.active) return ESP_ERR_INVALID_STATE;
+    if (effects == NULL || count == 0 || count > SOLAR_OS_DRV2605_WAVEFORM_MAX) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    for (size_t i = 0; i < count; i++) {
+        ESP_RETURN_ON_ERROR(
+            write_reg((uint8_t)(DRV2605_REG_WAVESEQ1 + i), effects[i]),
+            TAG, "seq slot write failed");
+    }
+    if (count < SOLAR_OS_DRV2605_WAVEFORM_MAX) {
+        ESP_RETURN_ON_ERROR(
+            write_reg((uint8_t)(DRV2605_REG_WAVESEQ1 + count), 0x00U),
+            TAG, "seq term failed");
+    }
+    ESP_RETURN_ON_ERROR(write_reg(DRV2605_REG_GO, DRV2605_GO), TAG, "go write failed");
+    return ESP_OK;
+}
+
+esp_err_t solar_os_drv2605_stop(void)
+{
+    if (!haptic_device.active) return ESP_ERR_INVALID_STATE;
+    return write_reg(DRV2605_REG_GO, DRV2605_STOP);
+}
+
+bool solar_os_drv2605_is_active(void)
+{
+    return haptic_device.active;
+}

--- a/src/services/solar_os_drv2605.h
+++ b/src/services/solar_os_drv2605.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "esp_err.h"
+#include "solar_os_expansion.h"
+
+#define SOLAR_OS_DRV2605_ADDRESS 0x5AU
+
+/* Maximum waveform slots in a sequence (DRV2605 supports up to 8). */
+#define SOLAR_OS_DRV2605_WAVEFORM_MAX 8U
+
+esp_err_t solar_os_drv2605_attach(const char *name,
+                                  const solar_os_expansion_binding_t *bindings,
+                                  size_t binding_count);
+esp_err_t solar_os_drv2605_detach(const char *name);
+
+/* Play one of the 123 built-in library effects (1–123). */
+esp_err_t solar_os_drv2605_play_effect(uint8_t effect_id);
+
+/* Play a waveform sequence (up to SOLAR_OS_DRV2605_WAVEFORM_MAX effect IDs,
+ * terminated by 0). Played back-to-back without gaps. */
+esp_err_t solar_os_drv2605_play_sequence(const uint8_t *effects, size_t count);
+
+esp_err_t solar_os_drv2605_stop(void);
+
+bool solar_os_drv2605_is_active(void);

--- a/src/services/solar_os_drv2605_driver.c
+++ b/src/services/solar_os_drv2605_driver.c
@@ -1,0 +1,19 @@
+#include "solar_os_drv2605.h"
+
+static const int addresses[] = {SOLAR_OS_DRV2605_ADDRESS};
+static const solar_os_expansion_binding_spec_t binding_specs[] = {
+    {.key = "i2c", .value_hint = "bus", .kind = SOLAR_OS_EXPANSION_BINDING_I2C_BUS, .required = true},
+    {.key = "addr", .value_hint = "0x5A", .kind = SOLAR_OS_EXPANSION_BINDING_I2C_ADDRESS, .required = true, .allowed_values = addresses, .allowed_value_count = sizeof(addresses) / sizeof(addresses[0])},
+};
+
+const solar_os_expansion_driver_t solar_os_drv2605_expansion_driver = {
+    .name = "drv2605",
+    .category = SOLAR_OS_EXPANSION_CATEGORY_OTHER,
+    .summary = "DRV2605 haptic driver",
+    .required_capabilities = SOLAR_OS_BOARD_CAP_I2C,
+    .probe_supported = false,
+    .binding_specs = binding_specs,
+    .binding_spec_count = sizeof(binding_specs) / sizeof(binding_specs[0]),
+    .attach = solar_os_drv2605_attach,
+    .detach = solar_os_drv2605_detach,
+};

--- a/src/services/solar_os_drv2605_driver.c
+++ b/src/services/solar_os_drv2605_driver.c
@@ -8,7 +8,7 @@ static const solar_os_expansion_binding_spec_t binding_specs[] = {
 
 const solar_os_expansion_driver_t solar_os_drv2605_expansion_driver = {
     .name = "drv2605",
-    .category = SOLAR_OS_EXPANSION_CATEGORY_OTHER,
+    .category = SOLAR_OS_EXPANSION_CATEGORY_UTILITY,
     .summary = "DRV2605 haptic driver",
     .required_capabilities = SOLAR_OS_BOARD_CAP_I2C,
     .probe_supported = false,

--- a/src/services/solar_os_gnss.c
+++ b/src/services/solar_os_gnss.c
@@ -91,8 +91,9 @@ esp_err_t solar_os_gnss_detach(const char *name)
         return ESP_ERR_NOT_FOUND;
     }
     const esp_err_t ret = solar_os_uart_unregister_bus(gnss.uart_bus);
-    if (ret == ESP_OK) {
+    if (ret == ESP_OK || ret == ESP_ERR_INVALID_STATE) {
         memset(&gnss, 0, sizeof(gnss));
+        return ESP_OK;
     }
     return ret;
 }

--- a/src/services/solar_os_gnss.c
+++ b/src/services/solar_os_gnss.c
@@ -4,14 +4,17 @@
 #include <stdbool.h>
 #include <string.h>
 
+#include "driver/uart.h"
 #include "esp_log.h"
 #include "solar_os_expansion.h"
 #include "solar_os_uart.h"
+#include "uart_port.h"
 
 typedef struct {
     bool active;
     char name[SOLAR_OS_EXPANSION_DEVICE_NAME_MAX];
     char uart_bus[SOLAR_OS_EXPANSION_TARGET_MAX];
+    uart_port_t port;
 } solar_os_gnss_device_t;
 
 static const char *TAG = "uart-gnss";
@@ -78,11 +81,29 @@ esp_err_t solar_os_gnss_attach(const char *name,
 
     memset(&gnss, 0, sizeof(gnss));
     gnss.active = true;
+    gnss.port   = (uart_port_t)port.port;
     strlcpy(gnss.name, name, sizeof(gnss.name));
     strlcpy(gnss.uart_bus, uart_bus, sizeof(gnss.uart_bus));
     ESP_LOGI(TAG, "%s attached on %s UART%d TX=%d RX=%d baud=%" PRIu32,
              name, uart_bus, port.port, port.tx_pin, port.rx_pin, port.baud_rate);
     return ESP_OK;
+}
+
+esp_err_t solar_os_gnss_read_raw(uint8_t *buf, size_t len,
+                                 uint32_t timeout_ms, size_t *read_len)
+{
+    if (!gnss.active || buf == NULL || len == 0) {
+        return ESP_ERR_INVALID_STATE;
+    }
+    return uart_port_read(gnss.port, buf, len, timeout_ms, read_len);
+}
+
+esp_err_t solar_os_gnss_write_raw(const uint8_t *buf, size_t len, size_t *written)
+{
+    if (!gnss.active || buf == NULL || len == 0) {
+        return ESP_ERR_INVALID_STATE;
+    }
+    return uart_port_write(gnss.port, buf, len, written);
 }
 
 esp_err_t solar_os_gnss_detach(const char *name)

--- a/src/services/solar_os_gnss.c
+++ b/src/services/solar_os_gnss.c
@@ -1,0 +1,98 @@
+#include "solar_os_gnss.h"
+
+#include <inttypes.h>
+#include <stdbool.h>
+#include <string.h>
+
+#include "esp_log.h"
+#include "solar_os_expansion.h"
+#include "solar_os_uart.h"
+
+typedef struct {
+    bool active;
+    char name[SOLAR_OS_EXPANSION_DEVICE_NAME_MAX];
+    char uart_bus[SOLAR_OS_EXPANSION_TARGET_MAX];
+} solar_os_gnss_device_t;
+
+static const char *TAG = "uart-gnss";
+static solar_os_gnss_device_t gnss;
+
+static esp_err_t parse_bindings(const solar_os_expansion_binding_t *bindings,
+                                size_t binding_count,
+                                char *uart_bus,
+                                size_t uart_bus_len)
+{
+    bool have_uart = false;
+
+    if (bindings == NULL || uart_bus == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    uart_bus[0] = '\0';
+
+    for (size_t i = 0; i < binding_count; i++) {
+        const solar_os_expansion_binding_t *b = &bindings[i];
+        if (b->kind == SOLAR_OS_EXPANSION_BINDING_UART_PORT) {
+            if (have_uart) {
+                return ESP_ERR_INVALID_ARG;
+            }
+            strlcpy(uart_bus, b->target, uart_bus_len);
+            have_uart = true;
+        } else {
+            return ESP_ERR_INVALID_ARG;
+        }
+    }
+    return have_uart ? ESP_OK : ESP_ERR_INVALID_ARG;
+}
+
+esp_err_t solar_os_gnss_attach(const char *name,
+                               const solar_os_expansion_binding_t *bindings,
+                               size_t binding_count)
+{
+    char uart_bus[SOLAR_OS_EXPANSION_TARGET_MAX];
+
+    if (name == NULL || name[0] == '\0' || gnss.active) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    esp_err_t ret = parse_bindings(bindings, binding_count,
+                                   uart_bus, sizeof(uart_bus));
+    if (ret != ESP_OK) {
+        return ret;
+    }
+
+    solar_os_expansion_uart_port_t port;
+    if (!solar_os_expansion_find_uart_port(uart_bus, &port, NULL)) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    const solar_os_bus_uart_config_t config = {
+        .port     = port.port,
+        .tx_pin   = port.tx_pin,
+        .rx_pin   = port.rx_pin,
+        .baud_rate = port.baud_rate,
+    };
+    ret = solar_os_uart_register_bus(uart_bus, &config, false);
+    if (ret != ESP_OK) {
+        return ret;
+    }
+
+    memset(&gnss, 0, sizeof(gnss));
+    gnss.active = true;
+    strlcpy(gnss.name, name, sizeof(gnss.name));
+    strlcpy(gnss.uart_bus, uart_bus, sizeof(gnss.uart_bus));
+    ESP_LOGI(TAG, "%s attached on %s UART%d TX=%d RX=%d baud=%" PRIu32,
+             name, uart_bus, port.port, port.tx_pin, port.rx_pin, port.baud_rate);
+    return ESP_OK;
+}
+
+esp_err_t solar_os_gnss_detach(const char *name)
+{
+    if (!gnss.active || name == NULL || strcmp(gnss.name, name) != 0) {
+        return ESP_ERR_NOT_FOUND;
+    }
+    const esp_err_t ret = solar_os_uart_unregister_bus(gnss.uart_bus);
+    if (ret == ESP_OK) {
+        memset(&gnss, 0, sizeof(gnss));
+    }
+    return ret;
+}

--- a/src/services/solar_os_gnss.h
+++ b/src/services/solar_os_gnss.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <stddef.h>
+#include <stdint.h>
 
 #include "esp_err.h"
 #include "solar_os_expansion.h"
@@ -9,3 +10,6 @@ esp_err_t solar_os_gnss_attach(const char *name,
                                const solar_os_expansion_binding_t *bindings,
                                size_t binding_count);
 esp_err_t solar_os_gnss_detach(const char *name);
+esp_err_t solar_os_gnss_read_raw(uint8_t *buf, size_t len,
+                                 uint32_t timeout_ms, size_t *read_len);
+esp_err_t solar_os_gnss_write_raw(const uint8_t *buf, size_t len, size_t *written);

--- a/src/services/solar_os_gnss.h
+++ b/src/services/solar_os_gnss.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <stddef.h>
+
+#include "esp_err.h"
+#include "solar_os_expansion.h"
+
+esp_err_t solar_os_gnss_attach(const char *name,
+                               const solar_os_expansion_binding_t *bindings,
+                               size_t binding_count);
+esp_err_t solar_os_gnss_detach(const char *name);

--- a/src/services/solar_os_gnss_driver.c
+++ b/src/services/solar_os_gnss_driver.c
@@ -15,7 +15,6 @@ static const solar_os_expansion_binding_spec_t binding_specs[] = {
 const solar_os_expansion_driver_t solar_os_gnss_expansion_driver = {
     .name                 = "uart-gnss",
     .summary              = "UART GNSS module",
-    .category             = SOLAR_OS_EXPANSION_CATEGORY_SENSOR,
     .required_capabilities = SOLAR_OS_BOARD_CAP_EXPANSION_UART,
     .probe_supported      = false,
     .binding_specs        = binding_specs,

--- a/src/services/solar_os_gnss_driver.c
+++ b/src/services/solar_os_gnss_driver.c
@@ -1,0 +1,25 @@
+#include "solar_os_gnss.h"
+
+#include "solar_os_board_caps.h"
+#include "solar_os_expansion.h"
+
+static const solar_os_expansion_binding_spec_t binding_specs[] = {
+    {
+        .key        = "uart",
+        .value_hint = "bus",
+        .kind       = SOLAR_OS_EXPANSION_BINDING_UART_PORT,
+        .required   = true,
+    },
+};
+
+const solar_os_expansion_driver_t solar_os_gnss_expansion_driver = {
+    .name                 = "uart-gnss",
+    .summary              = "UART GNSS module",
+    .category             = SOLAR_OS_EXPANSION_CATEGORY_SENSOR,
+    .required_capabilities = SOLAR_OS_BOARD_CAP_EXPANSION_UART,
+    .probe_supported      = false,
+    .binding_specs        = binding_specs,
+    .binding_spec_count   = sizeof(binding_specs) / sizeof(binding_specs[0]),
+    .attach               = solar_os_gnss_attach,
+    .detach               = solar_os_gnss_detach,
+};

--- a/src/services/solar_os_st25r3916.c
+++ b/src/services/solar_os_st25r3916.c
@@ -1,0 +1,521 @@
+#include "solar_os_st25r3916.h"
+
+#include <stdbool.h>
+#include <string.h>
+
+#include "esp_check.h"
+#include "esp_log.h"
+#include "esp_timer.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "solar_os_buses.h"
+
+/*
+ * ST25R3916 NFC reader/writer for the LilyGO T-LoRa-Pager.
+ *
+ * SPI protocol (CPOL=0, CPHA=0, CS active low):
+ *   Write register : [0x00 | (reg & 0x3F), value]
+ *   Read  register : [0x40 | (reg & 0x3F), 0x00]  → byte[1]
+ *   Direct command : [0xC0 | (cmd & 0x3F)]
+ *   FIFO write     : [0x80, data...]
+ *   FIFO read      : [0x9F, 0x00...]  → bytes[1..]
+ *
+ * Power via XL9555 Port0 bit5 (NFC_EN), asserted HIGH by default.
+ * Chip identity register 0x1C returns 0xA0 (ST25R3916) or 0xA1 (B variant).
+ */
+
+#define ST25R3916_SPI_SPEED_HZ 4000000U
+#define ST25R3916_SPI_MODE     0  /* CPOL=0, CPHA=0 */
+
+/* Register map (selected subset for ISO 14443A) */
+#define REG_IO_CONF1           0x00U
+#define REG_IO_CONF2           0x01U
+#define REG_OP_CONTROL         0x02U
+#define REG_MODE               0x03U
+#define REG_BIT_RATE           0x04U
+#define REG_ISO14443A_NFC      0x05U
+#define REG_AUX                0x09U
+#define REG_TX_DRIVER          0x10U
+#define REG_FIELD_THRESHOLD_ACT 0x11U
+#define REG_FIELD_THRESHOLD_DEACT 0x12U
+#define REG_TIMER_EMV_CONTROL  0x15U
+#define REG_NO_RESPONSE_TIMER1 0x16U
+#define REG_NO_RESPONSE_TIMER2 0x17U
+#define REG_GPT_CONTROL        0x18U
+#define REG_MASK_RX_TIMER      0x1AU
+#define REG_PASSIVE_TARGET_DEF 0x1BU
+#define REG_IC_IDENTITY        0x1CU  /* returns 0xA0 (ST25R3916) / 0xA1 (B) */
+#define REG_EMD_SUP_CONF       0x0EU
+#define REG_SUBC_START_TIME    0x0FU
+#define REG_RX_CONF1           0x06U
+#define REG_RX_CONF2           0x07U
+#define REG_RX_CONF3           0x08U
+#define REG_FIFO_STATUS1       0x1DU
+#define REG_FIFO_STATUS2       0x1EU
+#define REG_COLLISION_STATUS   0x1FU
+#define REG_NUM_TX_BYTES1      0x20U
+#define REG_NUM_TX_BYTES2      0x21U
+#define REG_NFCIP1_BIT_RATE    0x22U
+#define REG_AUX_DISPLAY        0x23U
+#define REG_RSSI_RESULT        0x24U
+#define REG_GAIN_RED_STATE     0x25U
+#define REG_CAP_SENSOR_CONTROL 0x26U
+#define REG_CAP_SENSOR_RESULT  0x27U
+#define REG_AUXILIARY_DISPLAY  0x28U
+#define REG_OVERSHOOT_CONF1    0x30U
+#define REG_OVERSHOOT_CONF2    0x31U
+#define REG_UNDERSHOOT_CONF1   0x32U
+#define REG_UNDERSHOOT_CONF2   0x33U
+#define REG_INTERRUPT_MASK_MAIN 0x34U
+#define REG_INTERRUPT_MASK_AUX 0x35U
+#define REG_INTERRUPT_MAIN     0x36U
+#define REG_INTERRUPT_AUX      0x37U
+
+/* Direct commands */
+#define CMD_SET_DEFAULT        0x01U
+#define CMD_STOP               0x02U
+#define CMD_TRANSMIT_NO_CRC    0x04U
+#define CMD_TRANSMIT_WITH_CRC  0x05U
+#define CMD_RECEIVE            0x06U
+#define CMD_UNMASK_RX          0x07U
+#define CMD_MEASURE_RSSI       0x0DU
+#define CMD_ADJUST_REGULATORS  0x0EU
+#define CMD_CAL_MODULATION     0x0FU
+#define CMD_CAL_ANTENNA        0x10U
+#define CMD_CAL_DRIVER         0x14U
+#define CMD_CLEAR_FIFO         0x0AU
+#define CMD_TRANSMIT_REQA      0x26U  /* REQA (7-bit short frame) */
+#define CMD_TRANSMIT_WUPA      0x28U  /* WUPA */
+#define CMD_NFC_INITIAL_FIELD_ON  0x17U
+#define CMD_NFC_RESPONSE_FIELD_ON 0x18U
+
+/* OP_CONTROL bits */
+#define OP_CONTROL_RX_EN    0x80U
+#define OP_CONTROL_RX_MAN   0x40U
+#define OP_CONTROL_TX_EN    0x08U
+#define OP_CONTROL_RF_EN    0x02U
+
+/* MODE register values */
+#define MODE_ISO14443A      0x08U  /* nfc_ar=0, om[3:0]=0x8 = ISO14443A/NFC-A */
+
+/* SPI command byte prefixes */
+#define SPI_CMD_WRITE  0x00U
+#define SPI_CMD_READ   0x40U
+#define SPI_CMD_DIRECT 0xC0U
+#define SPI_CMD_FIFO_W 0x80U
+#define SPI_CMD_FIFO_R 0x9FU
+
+typedef struct {
+    bool active;
+    bool chip_ready;  /* true after successful chip init */
+    char name[SOLAR_OS_EXPANSION_DEVICE_NAME_MAX];
+    char spi_bus[SOLAR_OS_EXPANSION_TARGET_MAX];
+    int cs_pin;
+    int irq_pin;
+} solar_os_st25r3916_device_t;
+
+static const char *TAG = "st25r3916";
+static solar_os_st25r3916_device_t nfc_device;
+
+/* ---- Low-level SPI helpers ---- */
+
+static esp_err_t reg_write(uint8_t reg, uint8_t val)
+{
+    uint8_t tx[2] = {(uint8_t)(SPI_CMD_WRITE | (reg & 0x3FU)), val};
+    uint8_t rx[2] = {0};
+    return solar_os_bus_spi_transfer(nfc_device.spi_bus, nfc_device.cs_pin,
+                                     ST25R3916_SPI_MODE, ST25R3916_SPI_SPEED_HZ,
+                                     tx, rx, 2);
+}
+
+static esp_err_t reg_read(uint8_t reg, uint8_t *val)
+{
+    uint8_t tx[2] = {(uint8_t)(SPI_CMD_READ | (reg & 0x3FU)), 0x00U};
+    uint8_t rx[2] = {0};
+    esp_err_t err = solar_os_bus_spi_transfer(nfc_device.spi_bus, nfc_device.cs_pin,
+                                              ST25R3916_SPI_MODE, ST25R3916_SPI_SPEED_HZ,
+                                              tx, rx, 2);
+    if (err == ESP_OK) {
+        *val = rx[1];
+    }
+    return err;
+}
+
+static esp_err_t direct_cmd(uint8_t cmd)
+{
+    uint8_t tx[1] = {(uint8_t)(SPI_CMD_DIRECT | (cmd & 0x3FU))};
+    uint8_t rx[1] = {0};
+    return solar_os_bus_spi_transfer(nfc_device.spi_bus, nfc_device.cs_pin,
+                                     ST25R3916_SPI_MODE, ST25R3916_SPI_SPEED_HZ,
+                                     tx, rx, 1);
+}
+
+static esp_err_t fifo_read(uint8_t *buf, size_t len)
+{
+    if (len == 0 || buf == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    uint8_t tx[33] = {SPI_CMD_FIFO_R};  /* max 32 bytes useful FIFO + 1 cmd byte */
+    uint8_t rx[33] = {0};
+    const size_t total = 1 + len;
+    if (total > sizeof(tx)) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    esp_err_t err = solar_os_bus_spi_transfer(nfc_device.spi_bus, nfc_device.cs_pin,
+                                              ST25R3916_SPI_MODE, ST25R3916_SPI_SPEED_HZ,
+                                              tx, rx, total);
+    if (err == ESP_OK) {
+        memcpy(buf, &rx[1], len);
+    }
+    return err;
+}
+
+static esp_err_t fifo_write(const uint8_t *buf, size_t len)
+{
+    if (len == 0 || buf == NULL || len > 32) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    uint8_t tx[33] = {SPI_CMD_FIFO_W};
+    uint8_t rx[33] = {0};
+    memcpy(&tx[1], buf, len);
+    return solar_os_bus_spi_transfer(nfc_device.spi_bus, nfc_device.cs_pin,
+                                     ST25R3916_SPI_MODE, ST25R3916_SPI_SPEED_HZ,
+                                     tx, rx, 1 + len);
+}
+
+static esp_err_t reg_set_bits(uint8_t reg, uint8_t mask)
+{
+    uint8_t val = 0;
+    ESP_RETURN_ON_ERROR(reg_read(reg, &val), TAG, "reg_read failed");
+    return reg_write(reg, val | mask);
+}
+
+static esp_err_t reg_clear_bits(uint8_t reg, uint8_t mask)
+{
+    uint8_t val = 0;
+    ESP_RETURN_ON_ERROR(reg_read(reg, &val), TAG, "reg_read failed");
+    return reg_write(reg, val & (uint8_t)~mask);
+}
+
+/* ---- Chip init ---- */
+
+static esp_err_t st25r3916_chip_init(void)
+{
+    uint8_t id = 0;
+
+    ESP_RETURN_ON_ERROR(direct_cmd(CMD_SET_DEFAULT), TAG, "SET_DEFAULT failed");
+    vTaskDelay(pdMS_TO_TICKS(2));
+
+    ESP_RETURN_ON_ERROR(reg_read(REG_IC_IDENTITY, &id), TAG, "IC identity read failed");
+    if ((id & 0xF8U) != 0xA0U) {
+        ESP_LOGE(TAG, "unexpected IC identity 0x%02X (expected 0xA0 or 0xA1)", id);
+        return ESP_ERR_NOT_FOUND;
+    }
+    ESP_LOGI(TAG, "ST25R3916%s detected (IC identity 0x%02X)",
+             (id & 0x01U) ? "B" : "", id);
+
+    ESP_RETURN_ON_ERROR(direct_cmd(CMD_ADJUST_REGULATORS), TAG, "adjust regulators failed");
+    vTaskDelay(pdMS_TO_TICKS(2));
+
+    /* Mask all interrupts; we poll FIFO/status registers directly. */
+    ESP_RETURN_ON_ERROR(reg_write(REG_INTERRUPT_MASK_MAIN, 0xFFU), TAG, "mask irq main");
+    ESP_RETURN_ON_ERROR(reg_write(REG_INTERRUPT_MASK_AUX,  0xFFU), TAG, "mask irq aux");
+
+    /* TX/RX clocks on, RF field off until scan. */
+    ESP_RETURN_ON_ERROR(reg_write(REG_OP_CONTROL, OP_CONTROL_TX_EN | OP_CONTROL_RX_EN),
+                        TAG, "op_control init");
+
+    return ESP_OK;
+}
+
+/* ---- ISO 14443A helpers ---- */
+
+static esp_err_t iso14443a_field_on(void)
+{
+    ESP_RETURN_ON_ERROR(reg_set_bits(REG_OP_CONTROL, OP_CONTROL_RF_EN), TAG, "rf on");
+    vTaskDelay(pdMS_TO_TICKS(5));  /* RF rise time */
+    return ESP_OK;
+}
+
+static esp_err_t iso14443a_field_off(void)
+{
+    return reg_clear_bits(REG_OP_CONTROL, OP_CONTROL_RF_EN);
+}
+
+static esp_err_t iso14443a_set_mode(void)
+{
+    /* ISO 14443A / NFC-A, 106 kbps */
+    ESP_RETURN_ON_ERROR(reg_write(REG_MODE, MODE_ISO14443A), TAG, "set mode");
+    ESP_RETURN_ON_ERROR(reg_write(REG_BIT_RATE, 0x00U), TAG, "set bit rate 106k");
+    return ESP_OK;
+}
+
+/* Wait for FIFO to contain at least `min_bytes` bytes, with timeout. */
+static esp_err_t wait_fifo(uint8_t min_bytes, uint32_t timeout_ms)
+{
+    const int64_t deadline = esp_timer_get_time() + (int64_t)timeout_ms * 1000LL;
+    while (esp_timer_get_time() < deadline) {
+        uint8_t fs1 = 0;
+        esp_err_t err = reg_read(REG_FIFO_STATUS1, &fs1);
+        if (err != ESP_OK) {
+            return err;
+        }
+        /* FIFO_STATUS1 bits [6:0] = number of bytes in receive FIFO */
+        if ((fs1 & 0x7FU) >= min_bytes) {
+            return ESP_OK;
+        }
+        vTaskDelay(1);
+    }
+    return ESP_ERR_TIMEOUT;
+}
+
+/* Send REQA and receive ATQA (2 bytes). */
+static esp_err_t iso14443a_reqa(uint8_t *atqa)
+{
+    ESP_RETURN_ON_ERROR(direct_cmd(CMD_CLEAR_FIFO), TAG, "clear fifo");
+
+    /* Mask collision bits off — allow incomplete byte framing for short frame */
+    ESP_RETURN_ON_ERROR(reg_set_bits(REG_ISO14443A_NFC, 0x01U), TAG, "iso14443a short frame");
+
+    /* Transmit REQA (0x26) as a 7-bit short frame */
+    ESP_RETURN_ON_ERROR(direct_cmd(CMD_TRANSMIT_REQA), TAG, "REQA tx");
+
+    /* ATQA is 2 bytes */
+    esp_err_t err = wait_fifo(2, 10);
+    if (err != ESP_OK) {
+        return ESP_ERR_NOT_FOUND;  /* No tag present */
+    }
+
+    ESP_RETURN_ON_ERROR(fifo_read(atqa, 2), TAG, "ATQA fifo read");
+    return ESP_OK;
+}
+
+/* ISO 14443A anticollision + SELECT for single / double / triple UID.
+ * Fills uid/uid_len/sak in *tag on success. */
+static esp_err_t iso14443a_anticoll_select(solar_os_st25r3916_tag_t *tag)
+{
+    static const uint8_t sel_cmds[3]   = {0x93U, 0x95U, 0x97U};
+    uint8_t uid_buf[10] = {0};
+    uint8_t uid_total = 0;
+
+    for (int cascade = 0; cascade < 3; cascade++) {
+        /* Anticollision: SEL + NVB=0x20, no UID bits known */
+        uint8_t acoll[2] = {sel_cmds[cascade], 0x20U};
+        ESP_RETURN_ON_ERROR(direct_cmd(CMD_CLEAR_FIFO), TAG, "clear fifo");
+        ESP_RETURN_ON_ERROR(fifo_write(acoll, 2), TAG, "acoll fifo write");
+        ESP_RETURN_ON_ERROR(direct_cmd(CMD_TRANSMIT_WITH_CRC), TAG, "acoll tx");
+
+        esp_err_t err = wait_fifo(5, 20);
+        if (err != ESP_OK) {
+            return ESP_ERR_NOT_FOUND;
+        }
+
+        uint8_t uid_cl[5] = {0};  /* CT + 3 UID bytes + BCC (4) or 4 bytes + BCC (5) */
+        ESP_RETURN_ON_ERROR(fifo_read(uid_cl, 5), TAG, "acoll fifo read");
+
+        /* SELECT: SEL + NVB=0x70 + 5 data bytes (uid_cl) */
+        uint8_t sel[7] = {sel_cmds[cascade], 0x70U,
+                          uid_cl[0], uid_cl[1], uid_cl[2], uid_cl[3], uid_cl[4]};
+        ESP_RETURN_ON_ERROR(direct_cmd(CMD_CLEAR_FIFO), TAG, "clear fifo");
+        ESP_RETURN_ON_ERROR(fifo_write(sel, 7), TAG, "sel fifo write");
+        ESP_RETURN_ON_ERROR(direct_cmd(CMD_TRANSMIT_WITH_CRC), TAG, "sel tx");
+
+        err = wait_fifo(1, 20);
+        if (err != ESP_OK) {
+            return ESP_ERR_NOT_FOUND;
+        }
+
+        uint8_t sak = 0;
+        ESP_RETURN_ON_ERROR(fifo_read(&sak, 1), TAG, "SAK fifo read");
+
+        if (uid_cl[0] == 0x88U) {
+            /* CT byte — cascade tag, take bytes 1..3 */
+            memcpy(&uid_buf[uid_total], &uid_cl[1], 3);
+            uid_total += 3;
+            /* SAK bit 2 set = more cascades */
+            if ((sak & 0x04U) == 0U) {
+                break;
+            }
+        } else {
+            /* Last cascade level — take bytes 0..3 */
+            memcpy(&uid_buf[uid_total], &uid_cl[0], 4);
+            uid_total += 4;
+            tag->sak = sak;
+            break;
+        }
+        tag->sak = sak;
+    }
+
+    if (uid_total == 0 || uid_total > SOLAR_OS_ST25R3916_UID_MAX) {
+        return ESP_ERR_INVALID_RESPONSE;
+    }
+    memcpy(tag->uid, uid_buf, uid_total);
+    tag->uid_len = uid_total;
+    return ESP_OK;
+}
+
+/* ---- Binding parser ---- */
+
+static esp_err_t parse_bindings(const solar_os_expansion_binding_t *bindings,
+                                size_t binding_count,
+                                char *spi_bus,
+                                size_t spi_bus_len,
+                                int *cs_pin,
+                                int *irq_pin)
+{
+    bool have_spi = false;
+    bool have_cs  = false;
+
+    if (bindings == NULL || spi_bus == NULL || cs_pin == NULL || irq_pin == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    spi_bus[0] = '\0';
+    *cs_pin  = -1;
+    *irq_pin = -1;
+
+    for (size_t i = 0; i < binding_count; i++) {
+        const solar_os_expansion_binding_t *b = &bindings[i];
+        switch (b->kind) {
+        case SOLAR_OS_EXPANSION_BINDING_SPI_BUS:
+            if (have_spi) {
+                return ESP_ERR_INVALID_ARG;
+            }
+            strlcpy(spi_bus, b->target, spi_bus_len);
+            have_spi = true;
+            break;
+        case SOLAR_OS_EXPANSION_BINDING_SPI_CS:
+            if (have_cs) {
+                return ESP_ERR_INVALID_ARG;
+            }
+            *cs_pin = b->value;
+            have_cs = true;
+            /* SPI_CS binding may also carry the bus name */
+            if (!have_spi && b->target[0] != '\0') {
+                strlcpy(spi_bus, b->target, spi_bus_len);
+                have_spi = true;
+            }
+            break;
+        case SOLAR_OS_EXPANSION_BINDING_GPIO:
+            if (b->role != NULL && strcmp(b->role, "irq") == 0) {
+                *irq_pin = b->value;
+            }
+            break;
+        default:
+            return ESP_ERR_INVALID_ARG;
+        }
+    }
+
+    return (have_spi && have_cs &&
+            solar_os_expansion_find_spi_bus(spi_bus, NULL, NULL) &&
+            solar_os_expansion_spi_cs_allowed(spi_bus, *cs_pin))
+        ? ESP_OK
+        : ESP_ERR_INVALID_ARG;
+}
+
+/* ---- Public API ---- */
+
+esp_err_t solar_os_st25r3916_attach(const char *name,
+                                    const solar_os_expansion_binding_t *bindings,
+                                    size_t binding_count)
+{
+    char spi_bus[SOLAR_OS_EXPANSION_TARGET_MAX] = {0};
+    int cs_pin  = -1;
+    int irq_pin = -1;
+
+    if (name == NULL || name[0] == '\0') {
+        return ESP_ERR_INVALID_ARG;
+    }
+    if (nfc_device.active) {
+        return ESP_ERR_INVALID_STATE;
+    }
+    ESP_RETURN_ON_ERROR(parse_bindings(bindings, binding_count,
+                                       spi_bus, sizeof(spi_bus),
+                                       &cs_pin, &irq_pin),
+                        TAG, "invalid bindings");
+
+    memset(&nfc_device, 0, sizeof(nfc_device));
+    strlcpy(nfc_device.name, name, sizeof(nfc_device.name));
+    strlcpy(nfc_device.spi_bus, spi_bus, sizeof(nfc_device.spi_bus));
+    nfc_device.cs_pin  = cs_pin;
+    nfc_device.irq_pin = irq_pin;
+    nfc_device.active  = true;
+
+    /* Attempt chip init now; if NFC_EN is low the chip won't respond and
+     * chip_ready stays false. scan() will retry init on first use. */
+    esp_err_t err = st25r3916_chip_init();
+    nfc_device.chip_ready = (err == ESP_OK);
+    if (err != ESP_OK) {
+        ESP_LOGW(TAG, "%s: chip not responding at attach (NFC power off?); "
+                 "will retry on first scan", name);
+    }
+
+    ESP_LOGI(TAG, "%s attached on %s cs=%d%s",
+             name, spi_bus, cs_pin,
+             irq_pin >= 0 ? " (irq wired)" : "");
+    return ESP_OK;
+}
+
+bool solar_os_st25r3916_is_ready(void)
+{
+    return nfc_device.active && nfc_device.chip_ready;
+}
+
+void solar_os_st25r3916_reset_chip(void)
+{
+    nfc_device.chip_ready = false;
+}
+
+esp_err_t solar_os_st25r3916_detach(const char *name)
+{
+    if (!nfc_device.active || name == NULL || strcmp(nfc_device.name, name) != 0) {
+        return ESP_ERR_NOT_FOUND;
+    }
+    iso14443a_field_off();
+    direct_cmd(CMD_STOP);
+    memset(&nfc_device, 0, sizeof(nfc_device));
+    return ESP_OK;
+}
+
+esp_err_t solar_os_st25r3916_scan(uint32_t timeout_ms, solar_os_st25r3916_tag_t *tag)
+{
+    if (!nfc_device.active) {
+        return ESP_ERR_INVALID_STATE;
+    }
+    if (tag == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    if (!nfc_device.chip_ready) {
+        esp_err_t err = st25r3916_chip_init();
+        if (err != ESP_OK) {
+            ESP_LOGE(TAG, "chip init failed (is NFC power on?): %s", esp_err_to_name(err));
+            return err;
+        }
+        nfc_device.chip_ready = true;
+    }
+
+    memset(tag, 0, sizeof(*tag));
+
+    ESP_RETURN_ON_ERROR(iso14443a_set_mode(), TAG, "set mode");
+    ESP_RETURN_ON_ERROR(iso14443a_field_on(), TAG, "field on");
+
+    const int64_t deadline = esp_timer_get_time() + (int64_t)timeout_ms * 1000LL;
+    esp_err_t result = ESP_ERR_NOT_FOUND;
+
+    do {
+        uint8_t atqa[2] = {0};
+        esp_err_t err = iso14443a_reqa(atqa);
+        if (err == ESP_OK) {
+            tag->atqa[0] = atqa[0];
+            tag->atqa[1] = atqa[1];
+            err = iso14443a_anticoll_select(tag);
+            if (err == ESP_OK) {
+                result = ESP_OK;
+                break;
+            }
+        }
+        vTaskDelay(pdMS_TO_TICKS(10));
+    } while (esp_timer_get_time() < deadline);
+
+    iso14443a_field_off();
+    return result;
+}

--- a/src/services/solar_os_st25r3916.h
+++ b/src/services/solar_os_st25r3916.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "esp_err.h"
+#include "solar_os_expansion.h"
+
+/* ST25R3916 default SPI CS GPIO on the LilyGO T-LoRa-Pager. */
+#define SOLAR_OS_ST25R3916_CS_GPIO  39
+#define SOLAR_OS_ST25R3916_IRQ_GPIO 5
+
+/* Maximum UID length for ISO 14443A (single/double/triple UID = 4/7/10 bytes). */
+#define SOLAR_OS_ST25R3916_UID_MAX 10U
+
+typedef struct {
+    uint8_t uid[SOLAR_OS_ST25R3916_UID_MAX];
+    uint8_t uid_len;
+    uint8_t sak;     /* Select Acknowledge — 0x20 = ISO 14443-4, 0x00 = Mifare Ultralight, etc. */
+    uint8_t atqa[2]; /* Answer To Request type A */
+} solar_os_st25r3916_tag_t;
+
+esp_err_t solar_os_st25r3916_attach(const char *name,
+                                    const solar_os_expansion_binding_t *bindings,
+                                    size_t binding_count);
+esp_err_t solar_os_st25r3916_detach(const char *name);
+
+/* Scan for an ISO 14443A tag; fills *tag on success. Returns ESP_ERR_NOT_FOUND
+ * when no tag is present within timeout_ms. */
+esp_err_t solar_os_st25r3916_scan(uint32_t timeout_ms, solar_os_st25r3916_tag_t *tag);
+
+/* True after a successful chip identity check (deferred until first scan if
+ * the chip was powered off at attach time). */
+bool solar_os_st25r3916_is_ready(void);
+
+/* Mark chip as needing re-initialisation (call after cutting NFC power). */
+void solar_os_st25r3916_reset_chip(void);

--- a/src/services/solar_os_st25r3916_driver.c
+++ b/src/services/solar_os_st25r3916_driver.c
@@ -1,0 +1,19 @@
+#include "solar_os_st25r3916.h"
+
+static const solar_os_expansion_binding_spec_t binding_specs[] = {
+    {.key = "spi", .value_hint = "bus", .kind = SOLAR_OS_EXPANSION_BINDING_SPI_BUS, .required = true},
+    {.key = "cs",  .value_hint = "gpio", .kind = SOLAR_OS_EXPANSION_BINDING_SPI_CS, .required = true},
+    {.key = "irq", .value_hint = "gpio", .kind = SOLAR_OS_EXPANSION_BINDING_GPIO, .role = "irq"},
+};
+
+const solar_os_expansion_driver_t solar_os_st25r3916_expansion_driver = {
+    .name = "st25r3916",
+    .category = SOLAR_OS_EXPANSION_CATEGORY_SENSOR,
+    .summary = "ST25R3916 NFC reader/writer (ISO 14443A)",
+    .required_capabilities = SOLAR_OS_BOARD_CAP_SPI,
+    .probe_supported = true,
+    .binding_specs = binding_specs,
+    .binding_spec_count = sizeof(binding_specs) / sizeof(binding_specs[0]),
+    .attach = solar_os_st25r3916_attach,
+    .detach = solar_os_st25r3916_detach,
+};

--- a/src/services/solar_os_tca8418.c
+++ b/src/services/solar_os_tca8418.c
@@ -12,6 +12,7 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "solar_os_buses.h"
+#include "solar_os_display.h"
 #include "solar_os_input.h"
 #include "solar_os_task.h"
 
@@ -46,7 +47,12 @@
 #define TCA8418_CAPS_KEY 0x1CU
 #define TCA8418_ALT_KEY 0x14U
 #define TCA8418_BACKSPACE_KEY 0x1DU
-#define TCA8418_ALT_BRIGHTNESS_KEY 0x19U
+#define TCA8418_ALT_BRIGHTNESS_KEY 0x19U  /* Alt+B: cycle display brightness */
+#define TCA8418_ALT_KBD_BACKLIGHT_KEY 0x11U  /* Alt+K: toggle keyboard backlight */
+
+/* Display brightness steps cycled by Alt+B (percent). */
+static const uint8_t brightness_steps[] = {20, 40, 60, 80, 100};
+#define BRIGHTNESS_STEP_COUNT (sizeof(brightness_steps) / sizeof(brightness_steps[0]))
 
 #define TCA8418_POLL_MS 15U
 
@@ -268,8 +274,34 @@ static bool handle_special_key(solar_os_tca8418_device_t *device,
         return true;
     }
     if (device->alt_pressed && k == TCA8418_ALT_BRIGHTNESS_KEY) {
-        /* Alt+B toggles the backlight on stock firmware. The control is not
-         * implemented yet in this port, so just swallow the key. */
+        if (pressed) {
+            uint8_t current = 0;
+            if (solar_os_display_get_brightness(&current) == ESP_OK) {
+                uint8_t next = brightness_steps[0];
+                for (size_t i = 0; i < BRIGHTNESS_STEP_COUNT; i++) {
+                    if (current <= brightness_steps[i]) {
+                        next = brightness_steps[(i + 1) % BRIGHTNESS_STEP_COUNT];
+                        break;
+                    }
+                }
+                solar_os_display_set_brightness(next);
+            }
+        }
+        return true;
+    }
+    if (device->alt_pressed && k == TCA8418_ALT_KBD_BACKLIGHT_KEY) {
+        if (pressed && device->backlight_pin >= 0) {
+            if (device->backlight_active) {
+                pwm_port_stop((gpio_num_t)device->backlight_pin);
+                device->backlight_active = false;
+            } else {
+                if (pwm_port_set((gpio_num_t)device->backlight_pin,
+                                 TCA8418_BACKLIGHT_PWM_HZ,
+                                 TCA8418_BACKLIGHT_DEFAULT_PERCENT) == ESP_OK) {
+                    device->backlight_active = true;
+                }
+            }
+        }
         return true;
     }
     return false;

--- a/src/services/solar_os_tlora_pager_core.c
+++ b/src/services/solar_os_tlora_pager_core.c
@@ -36,9 +36,11 @@
 #define XL9555_REG_CONFIG_PORT1 0x07U
 
 /* Port0 bit0..7: DRV_EN, AMP_EN, KB_RST, LORA_EN, GPS_EN, NFC_EN, (NC), GPS_RST */
-#define XL9555_PORT0_OUTPUT_VALUE 0xBFU
+/* GPS_EN (bit4) and NFC_EN (bit5) are left LOW at boot — power them on explicitly. */
+#define XL9555_PORT0_OUTPUT_VALUE 0x8FU
 #define XL9555_PORT0_CONFIG_VALUE 0x40U /* bit6 (NC) left as input; the rest are outputs */
 #define XL9555_PORT0_GPS_EN_BIT   0x10U /* bit4: GPS power enable, active HIGH */
+#define XL9555_PORT0_NFC_EN_BIT   0x20U /* bit5: NFC power enable, active HIGH */
 
 /* Port1 bit0..7 (global bit8..15): KB_EN, GPIO_EN, SD_DET, SD_PULLEN, SD_EN, (NC x3) */
 /* SD_PULLEN (bit3) enables hardware pullups on SD data lines — must be driven HIGH */
@@ -201,4 +203,25 @@ bool solar_os_tlora_pager_core_get_gnss_power(void)
 {
     return core_device.active &&
            (core_device.port0_output & XL9555_PORT0_GPS_EN_BIT) != 0U;
+}
+
+esp_err_t solar_os_tlora_pager_core_set_nfc_power(bool on)
+{
+    if (!core_device.active) {
+        return ESP_ERR_INVALID_STATE;
+    }
+    if (on) {
+        core_device.port0_output |= XL9555_PORT0_NFC_EN_BIT;
+    } else {
+        core_device.port0_output &= (uint8_t)~XL9555_PORT0_NFC_EN_BIT;
+    }
+    return solar_os_bus_i2c_write_reg(core_device.i2c_bus, core_device.address,
+                                      XL9555_REG_OUTPUT_PORT0,
+                                      &core_device.port0_output, 1);
+}
+
+bool solar_os_tlora_pager_core_get_nfc_power(void)
+{
+    return core_device.active &&
+           (core_device.port0_output & XL9555_PORT0_NFC_EN_BIT) != 0U;
 }

--- a/src/services/solar_os_tlora_pager_core.c
+++ b/src/services/solar_os_tlora_pager_core.c
@@ -40,8 +40,9 @@
 #define XL9555_PORT0_CONFIG_VALUE 0x40U /* bit6 (NC) left as input; the rest are outputs */
 
 /* Port1 bit0..7 (global bit8..15): KB_EN, GPIO_EN, SD_DET, SD_PULLEN, SD_EN, (NC x3) */
-#define XL9555_PORT1_OUTPUT_VALUE 0x13U
-#define XL9555_PORT1_CONFIG_VALUE 0xECU /* SD_DET/SD_PULLEN stay inputs; bits 5-7 unused stay inputs */
+/* SD_PULLEN (bit3) enables hardware pullups on SD data lines — must be driven HIGH */
+#define XL9555_PORT1_OUTPUT_VALUE 0x1BU
+#define XL9555_PORT1_CONFIG_VALUE 0xE4U /* SD_DET (bit2) stays input; bits 5-7 NC stay inputs */
 
 typedef struct {
     bool active;

--- a/src/services/solar_os_tlora_pager_core.c
+++ b/src/services/solar_os_tlora_pager_core.c
@@ -38,6 +38,7 @@
 /* Port0 bit0..7: DRV_EN, AMP_EN, KB_RST, LORA_EN, GPS_EN, NFC_EN, (NC), GPS_RST */
 #define XL9555_PORT0_OUTPUT_VALUE 0xBFU
 #define XL9555_PORT0_CONFIG_VALUE 0x40U /* bit6 (NC) left as input; the rest are outputs */
+#define XL9555_PORT0_GPS_EN_BIT   0x10U /* bit4: GPS power enable, active HIGH */
 
 /* Port1 bit0..7 (global bit8..15): KB_EN, GPIO_EN, SD_DET, SD_PULLEN, SD_EN, (NC x3) */
 /* SD_PULLEN (bit3) enables hardware pullups on SD data lines — must be driven HIGH */
@@ -49,6 +50,7 @@ typedef struct {
     char name[SOLAR_OS_EXPANSION_DEVICE_NAME_MAX];
     char i2c_bus[SOLAR_OS_EXPANSION_TARGET_MAX];
     uint8_t address;
+    uint8_t port0_output; /* shadow of XL9555 Port0 output latch */
 } solar_os_tlora_pager_core_device_t;
 
 static const char *TAG = "tlora-pager-core";
@@ -155,6 +157,7 @@ esp_err_t solar_os_tlora_pager_core_attach(const char *name,
     clear_device(&core_device);
     core_device.active = true;
     core_device.address = address;
+    core_device.port0_output = XL9555_PORT0_OUTPUT_VALUE;
     strlcpy(core_device.name, name, sizeof(core_device.name));
     strlcpy(core_device.i2c_bus, i2c_bus, sizeof(core_device.i2c_bus));
 
@@ -177,4 +180,25 @@ esp_err_t solar_os_tlora_pager_core_detach(const char *name)
      * and depending on this device having run once at boot. */
     clear_device(&core_device);
     return ESP_OK;
+}
+
+esp_err_t solar_os_tlora_pager_core_set_gnss_power(bool on)
+{
+    if (!core_device.active) {
+        return ESP_ERR_INVALID_STATE;
+    }
+    if (on) {
+        core_device.port0_output |= XL9555_PORT0_GPS_EN_BIT;
+    } else {
+        core_device.port0_output &= (uint8_t)~XL9555_PORT0_GPS_EN_BIT;
+    }
+    return solar_os_bus_i2c_write_reg(core_device.i2c_bus, core_device.address,
+                                      XL9555_REG_OUTPUT_PORT0,
+                                      &core_device.port0_output, 1);
+}
+
+bool solar_os_tlora_pager_core_get_gnss_power(void)
+{
+    return core_device.active &&
+           (core_device.port0_output & XL9555_PORT0_GPS_EN_BIT) != 0U;
 }

--- a/src/services/solar_os_tlora_pager_core.h
+++ b/src/services/solar_os_tlora_pager_core.h
@@ -12,3 +12,7 @@ esp_err_t solar_os_tlora_pager_core_attach(const char *name,
                                            const solar_os_expansion_binding_t *bindings,
                                            size_t binding_count);
 esp_err_t solar_os_tlora_pager_core_detach(const char *name);
+
+/* Toggle individual power rails on the XL9555. */
+esp_err_t solar_os_tlora_pager_core_set_gnss_power(bool on);
+bool solar_os_tlora_pager_core_get_gnss_power(void);

--- a/src/services/solar_os_tlora_pager_core.h
+++ b/src/services/solar_os_tlora_pager_core.h
@@ -16,3 +16,5 @@ esp_err_t solar_os_tlora_pager_core_detach(const char *name);
 /* Toggle individual power rails on the XL9555. */
 esp_err_t solar_os_tlora_pager_core_set_gnss_power(bool on);
 bool solar_os_tlora_pager_core_get_gnss_power(void);
+esp_err_t solar_os_tlora_pager_core_set_nfc_power(bool on);
+bool solar_os_tlora_pager_core_get_nfc_power(void);

--- a/src/shell/solar_os_shell_commands.h
+++ b/src/shell/solar_os_shell_commands.h
@@ -44,6 +44,9 @@ void solar_os_shell_cmd_engine(solar_os_context_t *ctx, int argc, char **argv);
 #if SOLAR_OS_PACKAGE_SERVICE_EXPANSION
 void solar_os_shell_cmd_expansion(solar_os_context_t *ctx, int argc, char **argv);
 #endif
+#if SOLAR_OS_PACKAGE_GNSS_UART
+void solar_os_shell_cmd_gnss(solar_os_context_t *ctx, int argc, char **argv);
+#endif
 void solar_os_shell_cmd_gpio(solar_os_context_t *ctx, int argc, char **argv);
 #if SOLAR_OS_PACKAGE_SERVICE_GATEWAY
 void solar_os_shell_cmd_gateway(solar_os_context_t *ctx, int argc, char **argv);

--- a/src/shell/solar_os_shell_commands.h
+++ b/src/shell/solar_os_shell_commands.h
@@ -47,6 +47,9 @@ void solar_os_shell_cmd_expansion(solar_os_context_t *ctx, int argc, char **argv
 #if SOLAR_OS_PACKAGE_GNSS_UART
 void solar_os_shell_cmd_gnss(solar_os_context_t *ctx, int argc, char **argv);
 #endif
+#if SOLAR_OS_PACKAGE_ST25R3916
+void solar_os_shell_cmd_nfc(solar_os_context_t *ctx, int argc, char **argv);
+#endif
 void solar_os_shell_cmd_gpio(solar_os_context_t *ctx, int argc, char **argv);
 #if SOLAR_OS_PACKAGE_SERVICE_GATEWAY
 void solar_os_shell_cmd_gateway(solar_os_context_t *ctx, int argc, char **argv);

--- a/src/shell/solar_os_shell_hardware.c
+++ b/src/shell/solar_os_shell_hardware.c
@@ -725,6 +725,127 @@ static void battery_cmd_max_voltage(solar_os_shell_io_t *term, int argc, char **
 }
 
 #if SOLAR_OS_PACKAGE_GNSS_UART
+static int gnss_field(const char *sentence, int field, char *out, size_t out_len)
+{
+    int f = 0;
+    const char *p = sentence;
+    while (*p && *p != '*') {
+        if (f == field) {
+            size_t n = 0;
+            while (*p && *p != ',' && *p != '*' && n + 1 < out_len) {
+                out[n++] = *p++;
+            }
+            out[n] = '\0';
+            return (int)n;
+        }
+        if (*p == ',') {
+            f++;
+        }
+        p++;
+    }
+    if (out_len > 0) out[0] = '\0';
+    return 0;
+}
+
+static void gnss_print_status(solar_os_shell_io_t *term, uint32_t timeout_ms)
+{
+    uint8_t buf[512];
+    size_t n = 0;
+    const esp_err_t err = solar_os_gnss_read_raw(buf, sizeof(buf) - 1, timeout_ms, &n);
+    if (err == ESP_ERR_INVALID_STATE) {
+        solar_os_shell_io_writeln(term, "gnss: no GNSS device attached");
+        return;
+    }
+    if (err != ESP_OK) {
+        solar_os_shell_io_printf(term, "gnss status failed: %s\n", solar_os_shell_error_text(err));
+        return;
+    }
+    if (n == 0) {
+        solar_os_shell_io_writeln(term, "gnss: no data (module silent or not powered)");
+        return;
+    }
+    buf[n] = '\0';
+
+    /* parse one GNGGA sentence for fix quality and sats used */
+    int fix_quality = -1;
+    int sats_used = -1;
+    /* parse GSV sentences: sum sats-in-view per talker (one entry per GPGSV/GAGSV/etc.) */
+    int gsv_sats_view = 0;
+    bool gsv_seen = false;
+    /* track which talkers already contributed their in-view count */
+    char seen_talkers[8][3];
+    int seen_count = 0;
+
+    const char *line = (const char *)buf;
+    while (line && *line) {
+        const char *end = strchr(line, '\n');
+        char sentence[128];
+        size_t line_len = end ? (size_t)(end - line) : strlen(line);
+        if (line_len >= sizeof(sentence)) {
+            line_len = sizeof(sentence) - 1;
+        }
+        memcpy(sentence, line, line_len);
+        sentence[line_len] = '\0';
+        /* strip trailing \r */
+        if (line_len > 0 && sentence[line_len - 1] == '\r') {
+            sentence[--line_len] = '\0';
+        }
+
+        if (sentence[0] == '$') {
+            char talker[3] = {sentence[1], sentence[2], '\0'};
+            char type[4] = {sentence[3], sentence[4], sentence[5], '\0'};
+
+            if (strcmp(type, "GGA") == 0 && fix_quality < 0) {
+                char fq[4], sv[4];
+                gnss_field(sentence, 6, fq, sizeof(fq));
+                gnss_field(sentence, 7, sv, sizeof(sv));
+                if (fq[0] >= '0' && fq[0] <= '9') fix_quality = fq[0] - '0';
+                if (sv[0] >= '0' && sv[0] <= '9') sats_used = atoi(sv);
+            }
+
+            if (strcmp(type, "GSV") == 0) {
+                /* field 1 = total messages, field 2 = message number, field 3 = sats in view */
+                char msg_num[4], total_sv[4];
+                gnss_field(sentence, 2, msg_num, sizeof(msg_num));
+                gnss_field(sentence, 3, total_sv, sizeof(total_sv));
+                /* only count on first message of each talker to avoid double-counting */
+                if (strcmp(msg_num, "1") == 0 && total_sv[0] >= '0') {
+                    bool already = false;
+                    for (int i = 0; i < seen_count; i++) {
+                        if (strcmp(seen_talkers[i], talker) == 0) { already = true; break; }
+                    }
+                    if (!already && seen_count < 8) {
+                        memcpy(seen_talkers[seen_count++], talker, 3);
+                        gsv_sats_view += atoi(total_sv);
+                        gsv_seen = true;
+                    }
+                }
+            }
+        }
+
+        line = end ? end + 1 : NULL;
+    }
+
+    static const char * const fix_names[] = {
+        "none", "GPS", "DGPS", "PPS", "RTK fixed", "RTK float",
+        "estimated", "manual", "simulation",
+    };
+    const char *fix_name = (fix_quality >= 0 && fix_quality <= 8) ?
+        fix_names[fix_quality] : "unknown";
+
+    solar_os_shell_io_printf(term, "Fix: %s\n", fix_name);
+    if (sats_used >= 0) {
+        solar_os_shell_io_printf(term, "Satellites used: %d\n", sats_used);
+    } else {
+        solar_os_shell_io_writeln(term, "Satellites used: unknown");
+    }
+    if (gsv_seen) {
+        solar_os_shell_io_printf(term, "Satellites in view: %d\n", gsv_sats_view);
+    } else {
+        solar_os_shell_io_writeln(term, "Satellites in view: unknown");
+    }
+}
+
 static void gnss_print_nmea(solar_os_shell_io_t *term, const uint8_t *data, size_t len)
 {
     for (size_t i = 0; i < len; i++) {
@@ -745,6 +866,25 @@ static void gnss_print_nmea(solar_os_shell_io_t *term, const uint8_t *data, size
 void solar_os_shell_cmd_gnss(solar_os_context_t *ctx, int argc, char **argv)
 {
     solar_os_shell_io_t *term = terminal(ctx);
+
+    if (argc == 1 || strcmp(argv[1], "status") == 0) {
+        if (argc > 3) {
+            solar_os_shell_diag_unexpected(term, "gnss status", argv[3],
+                                           "gnss status [ms]");
+            return;
+        }
+        size_t timeout_ms = 2000;
+        if (argc == 3) {
+            if (!parse_size_arg(argv[2], 100, 10000, &timeout_ms)) {
+                solar_os_shell_diag_invalid(term, "gnss status", "ms", argv[2],
+                                            "an integer from 100 to 10000",
+                                            "gnss status [ms]", false);
+                return;
+            }
+        }
+        gnss_print_status(term, (uint32_t)timeout_ms);
+        return;
+    }
 
     if (argc >= 2 && strcmp(argv[1], "write") == 0) {
         if (argc < 3) {
@@ -791,7 +931,7 @@ void solar_os_shell_cmd_gnss(solar_os_context_t *ctx, int argc, char **argv)
 
     if (argc < 2 || strcmp(argv[1], "nmea") != 0) {
         solar_os_shell_io_writeln(term,
-            "usage: gnss nmea [ms] [hex] | gnss write <text> | gnss reset");
+            "usage: gnss [status [ms]] | gnss nmea [ms] [hex] | gnss write <text> | gnss reset");
         return;
     }
 

--- a/src/shell/solar_os_shell_hardware.c
+++ b/src/shell/solar_os_shell_hardware.c
@@ -39,6 +39,9 @@
 #include "solar_os_terminal.h"
 #include "solar_os_time.h"
 #include "solar_os_uart.h"
+#if SOLAR_OS_PACKAGE_GNSS_UART
+#include "solar_os_gnss.h"
+#endif
 
 #define SOLAR_OS_SHELL_ARG_MAX 20
 #define I2C_READ_MAX_LEN 32
@@ -720,6 +723,140 @@ static void battery_cmd_max_voltage(solar_os_shell_io_t *term, int argc, char **
     const esp_err_t err = solar_os_battery_set_max_voltage_mv(voltage_mv);
     battery_print_config_result(term, "max_voltage", err);
 }
+
+#if SOLAR_OS_PACKAGE_GNSS_UART
+static void gnss_print_nmea(solar_os_shell_io_t *term, const uint8_t *data, size_t len)
+{
+    for (size_t i = 0; i < len; i++) {
+        const char c = (char)data[i];
+        if (c == '\r') {
+            continue;
+        } else if (c == '\n') {
+            solar_os_shell_io_put_char(term, '\n');
+        } else {
+            solar_os_shell_io_put_char(term, isprint((unsigned char)c) ? c : '.');
+        }
+    }
+    if (len > 0 && data[len - 1] != '\n') {
+        solar_os_shell_io_put_char(term, '\n');
+    }
+}
+
+void solar_os_shell_cmd_gnss(solar_os_context_t *ctx, int argc, char **argv)
+{
+    solar_os_shell_io_t *term = terminal(ctx);
+
+    if (argc >= 2 && strcmp(argv[1], "write") == 0) {
+        if (argc < 3) {
+            solar_os_shell_io_writeln(term, "usage: gnss write <text>");
+            return;
+        }
+        char buf[128];
+        size_t pos = 0;
+        for (int i = 2; i < argc && pos < sizeof(buf) - 3; i++) {
+            if (i > 2) buf[pos++] = ' ';
+            const size_t l = strlen(argv[i]);
+            const size_t copy = (pos + l >= sizeof(buf) - 3) ? sizeof(buf) - 3 - pos : l;
+            memcpy(buf + pos, argv[i], copy);
+            pos += copy;
+        }
+        buf[pos++] = '\r';
+        buf[pos++] = '\n';
+        size_t written = 0;
+        const esp_err_t werr = solar_os_gnss_write_raw((uint8_t *)buf, pos, &written);
+        if (werr != ESP_OK) {
+            solar_os_shell_io_printf(term, "gnss write failed: %s\n",
+                                     solar_os_shell_error_text(werr));
+        } else {
+            solar_os_shell_io_printf(term, "gnss write: %u bytes sent\n", (unsigned)written);
+        }
+        return;
+    }
+
+    if (argc == 2 && strcmp(argv[1], "reset") == 0) {
+        static const char pmtk[] =
+            "$PMTK314,0,1,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0*28\r\n";
+        size_t written = 0;
+        const esp_err_t werr = solar_os_gnss_write_raw(
+            (const uint8_t *)pmtk, strlen(pmtk), &written);
+        if (werr != ESP_OK) {
+            solar_os_shell_io_printf(term, "gnss reset failed: %s\n",
+                                     solar_os_shell_error_text(werr));
+        } else {
+            solar_os_shell_io_writeln(term,
+                "gnss reset: PMTK314 sent — run 'gnss nmea' in 1s to verify");
+        }
+        return;
+    }
+
+    if (argc < 2 || strcmp(argv[1], "nmea") != 0) {
+        solar_os_shell_io_writeln(term,
+            "usage: gnss nmea [ms] [hex] | gnss write <text> | gnss reset");
+        return;
+    }
+
+    size_t timeout_ms = 500;
+    if (argc == 3 && strcmp(argv[2], "hex") != 0) {
+        if (!parse_size_arg(argv[2], 100, 10000, &timeout_ms)) {
+            solar_os_shell_diag_invalid(term, "gnss nmea", "ms", argv[2],
+                                        "an integer from 100 to 10000",
+                                        "gnss nmea [ms] [hex]", false);
+            return;
+        }
+    } else if (argc == 4 && strcmp(argv[3], "hex") != 0) {
+        solar_os_shell_diag_unexpected(term, "gnss nmea", argv[3],
+                                        "gnss nmea [ms] [hex]");
+        return;
+    } else if (argc > 4) {
+        solar_os_shell_diag_unexpected(term, "gnss nmea", argv[4],
+                                        "gnss nmea [ms] [hex]");
+        return;
+    }
+
+    bool as_hex = (argc == 4 && strcmp(argv[3], "hex") == 0) ||
+                  (argc == 3 && strcmp(argv[2], "hex") == 0);
+
+    uint8_t buf[256];
+    size_t n = 0;
+    const esp_err_t err = solar_os_gnss_read_raw(buf, sizeof(buf) - 1,
+                                                  (uint32_t)timeout_ms, &n);
+    if (err == ESP_ERR_INVALID_STATE) {
+        solar_os_shell_io_writeln(term, "gnss: no GNSS device attached");
+        return;
+    }
+    if (err != ESP_OK) {
+        solar_os_shell_io_printf(term, "gnss nmea failed: %s\n",
+                                 solar_os_shell_error_text(err));
+        return;
+    }
+    if (n == 0) {
+        solar_os_shell_io_writeln(term, "gnss nmea: no data (module silent or not powered)");
+        return;
+    }
+    if (as_hex) {
+        solar_os_shell_io_printf(term, "gnss nmea: %u bytes\n", (unsigned)n);
+        for (size_t offset = 0; offset < n; offset += 16) {
+            const size_t line_len = n - offset > 16 ? 16 : n - offset;
+            solar_os_shell_io_printf(term, "%04x:", (unsigned)offset);
+            for (size_t i = 0; i < 16; i++) {
+                if (i < line_len) {
+                    solar_os_shell_io_printf(term, " %02x", buf[offset + i]);
+                } else {
+                    solar_os_shell_io_write(term, "   ");
+                }
+            }
+            solar_os_shell_io_write(term, "  ");
+            for (size_t i = 0; i < line_len; i++) {
+                const unsigned char ch = buf[offset + i];
+                solar_os_shell_io_put_char(term, isprint(ch) ? (char)ch : '.');
+            }
+            solar_os_shell_io_put_char(term, '\n');
+        }
+    } else {
+        gnss_print_nmea(term, buf, n);
+    }
+}
+#endif
 
 void solar_os_shell_cmd_battery(solar_os_context_t *ctx, int argc, char **argv)
 {

--- a/src/shell/solar_os_shell_hardware.c
+++ b/src/shell/solar_os_shell_hardware.c
@@ -42,6 +42,9 @@
 #if SOLAR_OS_PACKAGE_GNSS_UART
 #include "solar_os_gnss.h"
 #endif
+#if SOLAR_OS_PACKAGE_TLORA_PAGER_CORE
+#include "solar_os_tlora_pager_core.h"
+#endif
 
 #define SOLAR_OS_SHELL_ARG_MAX 20
 #define I2C_READ_MAX_LEN 32
@@ -886,6 +889,38 @@ void solar_os_shell_cmd_gnss(solar_os_context_t *ctx, int argc, char **argv)
         return;
     }
 
+#if SOLAR_OS_PACKAGE_TLORA_PAGER_CORE
+    if (argc >= 2 && strcmp(argv[1], "power") == 0) {
+        if (argc == 2) {
+            solar_os_shell_io_printf(term, "GNSS power: %s\n",
+                                     solar_os_tlora_pager_core_get_gnss_power() ? "on" : "off");
+            return;
+        }
+        if (argc != 3) {
+            solar_os_shell_diag_unexpected(term, "gnss power", argv[3], "gnss power [on|off]");
+            return;
+        }
+        bool on;
+        if (strcmp(argv[2], "on") == 0) {
+            on = true;
+        } else if (strcmp(argv[2], "off") == 0) {
+            on = false;
+        } else {
+            solar_os_shell_diag_invalid(term, "gnss power", "state", argv[2],
+                                        "on or off", "gnss power [on|off]", false);
+            return;
+        }
+        const esp_err_t perr = solar_os_tlora_pager_core_set_gnss_power(on);
+        if (perr != ESP_OK) {
+            solar_os_shell_io_printf(term, "gnss power failed: %s\n",
+                                     solar_os_shell_error_text(perr));
+        } else {
+            solar_os_shell_io_printf(term, "GNSS power: %s\n", on ? "on" : "off");
+        }
+        return;
+    }
+#endif
+
     if (argc >= 2 && strcmp(argv[1], "write") == 0) {
         if (argc < 3) {
             solar_os_shell_io_writeln(term, "usage: gnss write <text>");
@@ -931,7 +966,7 @@ void solar_os_shell_cmd_gnss(solar_os_context_t *ctx, int argc, char **argv)
 
     if (argc < 2 || strcmp(argv[1], "nmea") != 0) {
         solar_os_shell_io_writeln(term,
-            "usage: gnss [status [ms]] | gnss nmea [ms] [hex] | gnss write <text> | gnss reset");
+            "usage: gnss [status [ms]] | gnss power [on|off] | gnss nmea [ms] [hex] | gnss write <text> | gnss reset");
         return;
     }
 

--- a/src/shell/solar_os_shell_hardware.c
+++ b/src/shell/solar_os_shell_hardware.c
@@ -45,6 +45,9 @@
 #if SOLAR_OS_PACKAGE_TLORA_PAGER_CORE
 #include "solar_os_tlora_pager_core.h"
 #endif
+#if SOLAR_OS_PACKAGE_ST25R3916
+#include "solar_os_st25r3916.h"
+#endif
 
 #define SOLAR_OS_SHELL_ARG_MAX 20
 #define I2C_READ_MAX_LEN 32
@@ -1032,6 +1035,104 @@ void solar_os_shell_cmd_gnss(solar_os_context_t *ctx, int argc, char **argv)
     }
 }
 #endif
+
+#if SOLAR_OS_PACKAGE_ST25R3916
+void solar_os_shell_cmd_nfc(solar_os_context_t *ctx, int argc, char **argv)
+{
+    solar_os_shell_io_t *term = terminal(ctx);
+
+    /* Default subcommand: status */
+    const char *subcmd = (argc >= 2) ? argv[1] : "status";
+
+    if (strcmp(subcmd, "status") == 0) {
+        const bool attached = solar_os_st25r3916_is_ready();
+#if SOLAR_OS_PACKAGE_TLORA_PAGER_CORE
+        const bool powered = solar_os_tlora_pager_core_get_nfc_power();
+        solar_os_shell_io_printf(term, "nfc power:  %s\n", powered ? "on" : "off");
+#endif
+        solar_os_shell_io_printf(term, "nfc chip:   %s\n",
+                                 attached ? "ready" : "not initialised");
+        return;
+    }
+
+    if (strcmp(subcmd, "scan") == 0 || strcmp(subcmd, "read") == 0) {
+        uint32_t timeout_ms = 5000;
+        if (argc >= 3) {
+            char *end = NULL;
+            long v = strtol(argv[2], &end, 10);
+            if (end == argv[2] || *end != '\0' || v <= 0 || v > 60000) {
+                solar_os_shell_diag_invalid(term, "nfc scan", "ms", argv[2],
+                                            "1–60000", "nfc scan [ms]", false);
+                return;
+            }
+            timeout_ms = (uint32_t)v;
+        }
+        solar_os_st25r3916_tag_t tag;
+        solar_os_shell_io_printf(term, "nfc scan: waiting up to %u ms...\n", (unsigned)timeout_ms);
+        const esp_err_t err = solar_os_st25r3916_scan(timeout_ms, &tag);
+        if (err == ESP_ERR_INVALID_STATE) {
+            solar_os_shell_io_writeln(term, "nfc: no NFC device attached");
+        } else if (err == ESP_ERR_NOT_FOUND) {
+            solar_os_shell_io_writeln(term, "nfc scan: no tag found");
+        } else if (err != ESP_OK) {
+            solar_os_shell_io_printf(term, "nfc scan failed: %s\n", esp_err_to_name(err));
+        } else {
+            solar_os_shell_io_printf(term, "UID (%u bytes):", (unsigned)tag.uid_len);
+            for (size_t i = 0; i < tag.uid_len; i++) {
+                solar_os_shell_io_printf(term, " %02X", tag.uid[i]);
+            }
+            solar_os_shell_io_writeln(term, "");
+            solar_os_shell_io_printf(term, "ATQA: %02X %02X\n", tag.atqa[0], tag.atqa[1]);
+            solar_os_shell_io_printf(term, "SAK:  %02X", tag.sak);
+            if (tag.sak == 0x20U) {
+                solar_os_shell_io_writeln(term, "  (ISO 14443-4 / MIFARE DESFire)");
+            } else if ((tag.sak & 0x20U) == 0U && (tag.sak & 0x40U) == 0U) {
+                solar_os_shell_io_writeln(term, "  (MIFARE Classic / Ultralight)");
+            } else {
+                solar_os_shell_io_writeln(term, "");
+            }
+        }
+        return;
+    }
+
+#if SOLAR_OS_PACKAGE_TLORA_PAGER_CORE
+    if (strcmp(subcmd, "power") == 0) {
+        if (argc == 2) {
+            solar_os_shell_io_printf(term, "nfc power: %s\n",
+                                     solar_os_tlora_pager_core_get_nfc_power() ? "on" : "off");
+            return;
+        }
+        if (argc >= 4) {
+            solar_os_shell_diag_unexpected(term, "nfc power", argv[3], "nfc power [on|off]");
+            return;
+        }
+        bool on;
+        if (strcmp(argv[2], "on") == 0) {
+            on = true;
+        } else if (strcmp(argv[2], "off") == 0) {
+            on = false;
+        } else {
+            solar_os_shell_diag_invalid(term, "nfc power", "state", argv[2],
+                                        "on or off", "nfc power [on|off]", false);
+            return;
+        }
+        const esp_err_t perr = solar_os_tlora_pager_core_set_nfc_power(on);
+        if (perr != ESP_OK) {
+            solar_os_shell_io_printf(term, "nfc power failed: %s\n", esp_err_to_name(perr));
+        } else {
+            if (!on) {
+                solar_os_st25r3916_reset_chip();
+            }
+            solar_os_shell_io_printf(term, "nfc power: %s\n", on ? "on" : "off");
+        }
+        return;
+    }
+#endif /* SOLAR_OS_PACKAGE_TLORA_PAGER_CORE */
+
+    solar_os_shell_io_writeln(term,
+        "usage: nfc [status] | nfc scan [ms] | nfc read [ms] | nfc power [on|off]");
+}
+#endif /* SOLAR_OS_PACKAGE_ST25R3916 */
 
 void solar_os_shell_cmd_battery(solar_os_context_t *ctx, int argc, char **argv)
 {


### PR DESCRIPTION
Fixes and improvements to the existing T-LoRa-Pager port.

## SD card
- Enable SD_PULLEN pullup so the card mounts reliably

## GNSS (U-blox MIA-M10Q)
- Get GPS working (correct baud rate and pin assignment)
- Add raw read/write API to the GNSS service
- Add `gnss status`, `gnss nmea`, and `gnss write` shell commands
- Add gnss power [on|off] via the XL9555 GPS_EN rail

## NFC (ST25R3916)
- New SPI driver for ISO 14443A tag reading: chip identity verify, RF field control, REQA → ATQA → anticollision/SELECT → UID + SAK
- Add nfc status, nfc scan [ms] and nfc power [on|off] shell commands

## Power rails
GPS_EN and NFC_EN now start low at boot; both are opt-in at runtime via their respective power on commands

## Keyboard shortcuts
Alt+B cycles display brightness
Alt+K toggles the keyboard backlight
Verified on my hardware T-LoRa-Pager running latest FW: SD card mounts, GNSS acquires and reports satellite counts, GPS and NFC power toggles confirmed, haptic driver attaches and plays effects, both keyboard shortcuts work.